### PR TITLE
Improve CI workflows: fix double-run, add release tests, embed version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: Build
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
     tags-ignore: ["*"]
   pull_request:
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,21 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go vet ./...
+
+      - run: go test ./...
+
   release:
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,7 +51,7 @@ jobs:
         run: |
           ext=""
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
-          go build -ldflags="-s -w" -o "gtnh-daily-updater${ext}" .
+          go build -ldflags="-s -w -X github.com/caedis/gtnh-daily-updater/cmd.version=${GITHUB_REF_NAME}" -o "gtnh-daily-updater${ext}" .
 
       - name: Package
         run: |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "dev"
+
 var (
 	instanceDir string
 	installSide string
@@ -25,6 +27,7 @@ var rootCmd = &cobra.Command{
 	Use:           "gtnh-daily-updater",
 	Short:         "Update tool for GTNH daily builds",
 	Long:          "Automatically update GregTech: New Horizons daily modpack builds, including mod downloads and config merging.",
+	Version:       version,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- **Fix duplicate CI runs**: Narrow `build.yml` push trigger to `master` only — feature branch pushes that already have a PR no longer fire both the `push` and `pull_request` events simultaneously. Added a concurrency group to cancel stale in-progress runs.
- **Gate releases on tests**: Add a `test` job to `release.yml` (runs `go vet` and `go test`) that the build matrix `needs`, so a bad tag push won't produce broken release binaries.
- **Embed version in binary**: Release builds now inject the tag name via `-X cmd.version=${GITHUB_REF_NAME}`. Running `gtnh-daily-updater --version` will report the actual release tag; local dev builds show `dev`.

## Test plan

- [ ] Open a PR from a feature branch and confirm only one CI run appears (not two)
- [ ] Push a new commit to the PR and confirm the previous run is cancelled
- [ ] Push a tag and confirm the `test` job runs before the build matrix starts
- [ ] Download a release binary and run `gtnh-daily-updater --version` to confirm the tag is embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)