### PR TITLE
Add CurseForge mod source for extra mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Add extra mods from GitHub releases:
 gtnh-daily-updater extra add SomeMod --source github:Owner/Repo
 ```
 
+Add extra mods from CurseForge (latest release file):
+
+```bash
+gtnh-daily-updater extra add SomeMod --source curseforge:12345
+```
+
+Add extra mods from CurseForge (pinned file):
+
+```bash
+gtnh-daily-updater extra add SomeMod --source curseforge:12345/67890
+```
+
 Add extra mods from direct URL:
 
 ```bash
@@ -174,6 +186,22 @@ Or pass per command:
 
 ```bash
 gtnh-daily-updater update --github-token your_token_here
+```
+
+## CurseForge API Key
+
+Required to use `curseforge:` extra mod sources. Get a key at https://console.curseforge.com/.
+
+Provide via env var:
+
+```bash
+export CURSEFORGE_API_KEY=your_key_here
+```
+
+Or pass per command:
+
+```bash
+gtnh-daily-updater update --curseforge-key your_key_here
 ```
 
 ## Development

--- a/cmd/extra.go
+++ b/cmd/extra.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/curseforge"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/side"
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ var extraAddCmd = &cobra.Command{
 	Long: `Add a mod not in the daily manifest. Sources:
   - Default: looks up mod name in the GTNH assets database
   - --source github:Owner/Repo: downloads from GitHub releases
+  - --source curseforge:12345: downloads latest release from CurseForge project
+  - --source curseforge:12345/67890: downloads a specific CurseForge file
   - --source https://example.com/mod.jar: downloads from direct URL`,
 	Args: usageArgs(cobra.ExactArgs(1)),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -87,11 +90,25 @@ var extraAddCmd = &cobra.Command{
 				return fmt.Errorf("GitHub API returned HTTP %d for %q", resp.StatusCode, repo)
 			}
 			logging.Infof("  Validated GitHub repo: %s\n", repo)
+		} else if rest, ok := strings.CutPrefix(spec.Source, "curseforge:"); ok {
+			// CurseForge source — validate format
+			projectID, fileID, err := curseforge.ParseSource(rest)
+			if err != nil {
+				return wrapUsageError(fmt.Errorf("invalid --source %q: %w", spec.Source, err))
+			}
+			if getCurseForgeKey() == "" {
+				logging.Infof("  Warning: CURSEFORGE_API_KEY not set — set it before running update\n")
+			}
+			if fileID != 0 {
+				logging.Infof("  CurseForge source: project %d, file %d (pinned)\n", projectID, fileID)
+			} else {
+				logging.Infof("  CurseForge source: project %d (latest release)\n", projectID)
+			}
 		} else if strings.HasPrefix(spec.Source, "http://") || strings.HasPrefix(spec.Source, "https://") {
 			// Direct URL — just note it
 			logging.Infof("  Direct URL source: %s\n", spec.Source)
 		} else {
-			return wrapUsageError(fmt.Errorf("invalid source %q: must be empty (assets DB), github:Owner/Repo, or a URL", spec.Source))
+			return wrapUsageError(fmt.Errorf("invalid source %q: must be empty (assets DB), github:Owner/Repo, curseforge:12345, or a URL", spec.Source))
 		}
 
 		if state.ExtraMods == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,13 +14,14 @@ import (
 var version = "dev"
 
 var (
-	instanceDir string
-	installSide string
-	mode        string
-	githubToken string
-	profileName string
-	verbose     bool
-	logFile     string
+	instanceDir   string
+	installSide   string
+	mode          string
+	githubToken   string
+	curseforgeKey string
+	profileName   string
+	verbose       bool
+	logFile       string
 )
 
 var rootCmd = &cobra.Command{
@@ -103,6 +104,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&instanceDir, "instance-dir", "d", ".", "Minecraft instance root directory")
 	rootCmd.PersistentFlags().StringVar(&githubToken, "github-token", "", "GitHub token for private mod downloads (also reads GITHUB_TOKEN env)")
+	rootCmd.PersistentFlags().StringVar(&curseforgeKey, "curseforge-key", "", "CurseForge API key for CurseForge extra mods (also reads CURSEFORGE_API_KEY env)")
 	rootCmd.PersistentFlags().StringVar(&profileName, "profile", "", "Load a saved option profile by name")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write command output to a log file")
@@ -113,6 +115,13 @@ func getGithubToken() string {
 		return githubToken
 	}
 	return os.Getenv("GITHUB_TOKEN")
+}
+
+func getCurseForgeKey() string {
+	if curseforgeKey != "" {
+		return curseforgeKey
+	}
+	return os.Getenv("CURSEFORGE_API_KEY")
 }
 
 type usageError struct {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,14 +22,15 @@ var updateCmd = &cobra.Command{
 	Short: "Update mods and tracked pack files to the latest manifest build",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := updater.Options{
-			InstanceDir: instanceDir,
-			DryRun:      dryRun,
-			Force:       force,
-			Latest:      latest,
-			Concurrency: concurrency,
-			GithubToken: getGithubToken(),
-			CacheDir:    cacheDir,
-			NoCache:     noCache,
+			InstanceDir:   instanceDir,
+			DryRun:        dryRun,
+			Force:         force,
+			Latest:        latest,
+			Concurrency:   concurrency,
+			GithubToken:   getGithubToken(),
+			CurseForgeKey: getCurseForgeKey(),
+			CacheDir:      cacheDir,
+			NoCache:       noCache,
 		}
 
 		result, err := updater.Run(context.Background(), opts)

--- a/cmd/update_all.go
+++ b/cmd/update_all.go
@@ -55,8 +55,9 @@ var updateAllCmd = &cobra.Command{
 
 			// Build options: CLI-flag-wins over profile values.
 			opts := updater.Options{
-				InstanceDir: *p.InstanceDir,
-				GithubToken: getGithubToken(),
+				InstanceDir:   *p.InstanceDir,
+				GithubToken:   getGithubToken(),
+				CurseForgeKey: getCurseForgeKey(),
 			}
 
 			mode, modeErr := updater.DetectMode(*p.InstanceDir)

--- a/internal/curseforge/curseforge.go
+++ b/internal/curseforge/curseforge.go
@@ -1,0 +1,202 @@
+package curseforge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// GTNHGameVersion is the Minecraft version GTNH targets.
+const GTNHGameVersion = "1.7.10"
+
+// baseURL and httpClient are vars so tests can override them.
+var (
+	baseURL    = "https://api.curseforge.com"
+	httpClient = http.DefaultClient
+)
+
+// File represents a CurseForge file entry.
+type File struct {
+	ID           int      `json:"id"`
+	ModID        int      `json:"modId"`
+	DisplayName  string   `json:"displayName"`
+	FileName     string   `json:"fileName"`
+	DownloadURL  string   `json:"downloadUrl"` // may be empty for some files
+	ReleaseType  int      `json:"releaseType"` // 1=Release, 2=Beta, 3=Alpha
+	GameVersions []string `json:"gameVersions"`
+}
+
+type fileResponse struct {
+	Data File `json:"data"`
+}
+
+type filesResponse struct {
+	Data []File `json:"data"`
+}
+
+type downloadURLResponse struct {
+	Data string `json:"data"`
+}
+
+// ParseSource parses the part of a curseforge source after the "curseforge:" prefix.
+// Accepted formats:
+//   - "12345"       — project ID, use latest release file
+//   - "12345/67890" — project ID + file ID, use that specific file
+//
+// Returns projectID, fileID (0 if not specified), and an error.
+func ParseSource(s string) (projectID, fileID int, err error) {
+	if projStr, fileStr, hasFile := strings.Cut(s, "/"); hasFile {
+		projectID, err = strconv.Atoi(projStr)
+		if err != nil || projectID <= 0 {
+			return 0, 0, fmt.Errorf("invalid CurseForge project ID %q: must be a positive integer", projStr)
+		}
+		fileID, err = strconv.Atoi(fileStr)
+		if err != nil || fileID <= 0 {
+			return 0, 0, fmt.Errorf("invalid CurseForge file ID %q: must be a positive integer", fileStr)
+		}
+		return projectID, fileID, nil
+	}
+	projectID, err = strconv.Atoi(s)
+	if err != nil || projectID <= 0 {
+		return 0, 0, fmt.Errorf("invalid CurseForge project ID %q: must be a positive integer", s)
+	}
+	return projectID, 0, nil
+}
+
+// FetchLatestFile returns the latest release file for a CurseForge project.
+// If gameVersion is non-empty, only files tagged for that game version are considered.
+// The returned File's ID can be used as a stable version identifier.
+func FetchLatestFile(ctx context.Context, projectID int, gameVersion, apiKey string) (File, error) {
+	endpoint := fmt.Sprintf("%s/v1/mods/%d/files", baseURL, projectID)
+	if gameVersion != "" {
+		endpoint += "?" + url.Values{"gameVersion": {gameVersion}}.Encode()
+	}
+
+	req, err := newRequest(ctx, endpoint, apiKey)
+	if err != nil {
+		return File{}, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return File{}, fmt.Errorf("fetching CurseForge files for project %d: %w", projectID, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatus(resp.StatusCode, fmt.Sprintf("project %d files", projectID)); err != nil {
+		return File{}, err
+	}
+
+	var result filesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return File{}, fmt.Errorf("parsing CurseForge files response: %w", err)
+	}
+
+	// Keep release-type files only (ReleaseType 1 = Release)
+	var releases []File
+	for _, f := range result.Data {
+		if f.ReleaseType == 1 {
+			releases = append(releases, f)
+		}
+	}
+	if len(releases) == 0 {
+		return File{}, fmt.Errorf("no release files found for CurseForge project %d (gameVersion=%q)", projectID, gameVersion)
+	}
+
+	// Highest file ID = most recently uploaded
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].ID > releases[j].ID
+	})
+	return releases[0], nil
+}
+
+// FetchFile returns a specific file from a CurseForge project.
+func FetchFile(ctx context.Context, projectID, fileID int, apiKey string) (File, error) {
+	endpoint := fmt.Sprintf("%s/v1/mods/%d/files/%d", baseURL, projectID, fileID)
+
+	req, err := newRequest(ctx, endpoint, apiKey)
+	if err != nil {
+		return File{}, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return File{}, fmt.Errorf("fetching CurseForge file %d for project %d: %w", fileID, projectID, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatus(resp.StatusCode, fmt.Sprintf("project %d file %d", projectID, fileID)); err != nil {
+		return File{}, err
+	}
+
+	var result fileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return File{}, fmt.Errorf("parsing CurseForge file response: %w", err)
+	}
+	return result.Data, nil
+}
+
+// ResolveDownloadURL returns the download URL for a file.
+// If the File's DownloadURL is empty (some mods require an extra API call), it
+// fetches the URL from the /download-url endpoint.
+func ResolveDownloadURL(ctx context.Context, projectID int, file File, apiKey string) (string, error) {
+	if file.DownloadURL != "" {
+		return file.DownloadURL, nil
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/mods/%d/files/%d/download-url", baseURL, projectID, file.ID)
+	req, err := newRequest(ctx, endpoint, apiKey)
+	if err != nil {
+		return "", err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching CurseForge download URL for file %d: %w", file.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatus(resp.StatusCode, fmt.Sprintf("project %d file %d download-url", projectID, file.ID)); err != nil {
+		return "", err
+	}
+
+	var result downloadURLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("parsing CurseForge download URL response: %w", err)
+	}
+	if result.Data == "" {
+		return "", fmt.Errorf("CurseForge returned empty download URL for file %d", file.ID)
+	}
+	return result.Data, nil
+}
+
+// FileVersion returns a stable version string for a CurseForge file.
+// The file ID is used since it is unique and monotonically increasing.
+func FileVersion(file File) string {
+	return strconv.Itoa(file.ID)
+}
+
+func newRequest(ctx context.Context, endpoint, apiKey string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func checkStatus(code int, target string) error {
+	switch code {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("CurseForge API key rejected (HTTP %d) — set CURSEFORGE_API_KEY", code)
+	case http.StatusNotFound:
+		return fmt.Errorf("CurseForge resource not found: %s", target)
+	default:
+		return fmt.Errorf("CurseForge API returned HTTP %d for %s", code, target)
+	}
+}

--- a/internal/curseforge/curseforge_test.go
+++ b/internal/curseforge/curseforge_test.go
@@ -1,0 +1,220 @@
+package curseforge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantProject int
+		wantFile    int
+		wantErr     bool
+	}{
+		{name: "project only", input: "238222", wantProject: 238222, wantFile: 0},
+		{name: "project and file", input: "238222/4586932", wantProject: 238222, wantFile: 4586932},
+		{name: "invalid project letters", input: "abc", wantErr: true},
+		{name: "invalid file letters", input: "238222/abc", wantErr: true},
+		{name: "zero project", input: "0", wantErr: true},
+		{name: "negative project", input: "-1", wantErr: true},
+		{name: "zero file", input: "238222/0", wantErr: true},
+		{name: "negative file", input: "238222/-5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proj, file, err := ParseSource(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSource(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSource(%q) unexpected error: %v", tt.input, err)
+			}
+			if proj != tt.wantProject || file != tt.wantFile {
+				t.Fatalf("ParseSource(%q) = (%d, %d), want (%d, %d)", tt.input, proj, file, tt.wantProject, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestFetchLatestFilePrefersNewestRelease(t *testing.T) {
+	files := []File{
+		{ID: 100, ReleaseType: 3, FileName: "alpha.jar", DownloadURL: "https://example.com/alpha.jar"},
+		{ID: 200, ReleaseType: 1, FileName: "old-release.jar", DownloadURL: "https://example.com/old.jar"},
+		{ID: 300, ReleaseType: 1, FileName: "latest-release.jar", DownloadURL: "https://example.com/latest.jar"},
+		{ID: 250, ReleaseType: 2, FileName: "beta.jar", DownloadURL: "https://example.com/beta.jar"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-api-key") == "" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(filesResponse{Data: files}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	got, err := FetchLatestFile(context.Background(), 12345, "", "test-key")
+	if err != nil {
+		t.Fatalf("FetchLatestFile: %v", err)
+	}
+	if got.ID != 300 {
+		t.Errorf("FetchLatestFile picked file ID %d, want 300", got.ID)
+	}
+	if got.FileName != "latest-release.jar" {
+		t.Errorf("FetchLatestFile picked filename %q, want latest-release.jar", got.FileName)
+	}
+}
+
+func TestFetchLatestFileErrorsOnNoReleases(t *testing.T) {
+	files := []File{
+		{ID: 100, ReleaseType: 3, FileName: "alpha.jar"},
+		{ID: 200, ReleaseType: 2, FileName: "beta.jar"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(filesResponse{Data: files}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	_, err := FetchLatestFile(context.Background(), 12345, "", "test-key")
+	if err == nil {
+		t.Fatal("FetchLatestFile: expected error for no releases, got nil")
+	}
+}
+
+func TestFetchFileReturnsPinnedFile(t *testing.T) {
+	want := File{
+		ID:          67890,
+		ModID:       12345,
+		FileName:    "pinned-mod.jar",
+		DownloadURL: "https://example.com/pinned-mod.jar",
+		ReleaseType: 1,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(fileResponse{Data: want}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	got, err := FetchFile(context.Background(), 12345, 67890, "test-key")
+	if err != nil {
+		t.Fatalf("FetchFile: %v", err)
+	}
+	if got.ID != want.ID || got.FileName != want.FileName {
+		t.Errorf("FetchFile got {ID:%d FileName:%q}, want {ID:%d FileName:%q}", got.ID, got.FileName, want.ID, want.FileName)
+	}
+}
+
+func TestResolveDownloadURLUsesFieldWhenPresent(t *testing.T) {
+	file := File{ID: 100, DownloadURL: "https://example.com/mod.jar"}
+	got, err := ResolveDownloadURL(context.Background(), 12345, file, "key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != file.DownloadURL {
+		t.Errorf("got %q, want %q", got, file.DownloadURL)
+	}
+}
+
+func TestResolveDownloadURLFetchesWhenEmpty(t *testing.T) {
+	wantURL := "https://edge.forgecdn.net/files/100/mod.jar"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(downloadURLResponse{Data: wantURL}); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	file := File{ID: 100, DownloadURL: ""}
+	got, err := ResolveDownloadURL(context.Background(), 12345, file, "test-key")
+	if err != nil {
+		t.Fatalf("ResolveDownloadURL: %v", err)
+	}
+	if got != wantURL {
+		t.Errorf("got %q, want %q", got, wantURL)
+	}
+}
+
+func TestCheckStatusRejectsMissingKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	_, err := FetchLatestFile(context.Background(), 12345, "", "bad-key")
+	if err == nil {
+		t.Fatal("expected error for 403, got nil")
+	}
+}
+
+func TestFileVersion(t *testing.T) {
+	f := File{ID: 4586932}
+	if got := FileVersion(f); got != "4586932" {
+		t.Errorf("FileVersion = %q, want %q", got, "4586932")
+	}
+}

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -537,6 +537,7 @@ func TestResolveExtraMod_GitHubSourceUsesAPIURLWithToken(t *testing.T) {
 		config.ExtraModSpec{Source: "github:owner/repo"},
 		nil,
 		"test-token",
+		"",
 		false,
 	)
 	if err != nil {
@@ -582,6 +583,7 @@ func TestResolveExtraMod_GitHubSourceUsesBrowserURLWithoutToken(t *testing.T) {
 		"mod",
 		config.ExtraModSpec{Source: "github:owner/repo"},
 		nil,
+		"",
 		"",
 		false,
 	)

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/curseforge"
 	"github.com/caedis/gtnh-daily-updater/internal/diff"
 	"github.com/caedis/gtnh-daily-updater/internal/downloader"
 	"github.com/caedis/gtnh-daily-updater/internal/github"
@@ -259,7 +261,7 @@ func resolveLatestVersions(ctx context.Context, db *assets.AssetsDB, changes []d
 }
 
 // resolveExtraMod resolves an extra mod spec into version/side info and download details.
-func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec, db *assets.AssetsDB, githubToken string, latest bool) (diff.ResolvedExtraMod, resolvedExtra, error) {
+func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec, db *assets.AssetsDB, githubToken, curseforgeKey string, latest bool) (diff.ResolvedExtraMod, resolvedExtra, error) {
 	modSide := spec.Side
 	if modSide == "" {
 		modSide = "BOTH"
@@ -312,6 +314,38 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 		}
 
 		return diff.ResolvedExtraMod{Version: version, Side: modSide}, dlInfo, nil
+
+	case strings.HasPrefix(spec.Source, "curseforge:"):
+		if curseforgeKey == "" {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("CURSEFORGE_API_KEY is required for CurseForge mods (set via env or --curseforge-key)")
+		}
+		rest := strings.TrimPrefix(spec.Source, "curseforge:")
+		projectID, fileID, err := curseforge.ParseSource(rest)
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		var file curseforge.File
+		if fileID != 0 {
+			file, err = curseforge.FetchFile(ctx, projectID, fileID, curseforgeKey)
+		} else {
+			file, err = curseforge.FetchLatestFile(ctx, projectID, curseforge.GTNHGameVersion, curseforgeKey)
+		}
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		downloadURL, err := curseforge.ResolveDownloadURL(ctx, projectID, file, curseforgeKey)
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		version := strconv.Itoa(file.ID)
+		logging.Debugf("Verbose: extra mod %s CurseForge project=%d file=%d filename=%s\n", name, projectID, file.ID, file.FileName)
+		return diff.ResolvedExtraMod{Version: version, Side: modSide}, resolvedExtra{
+			URL:      downloadURL,
+			Filename: file.FileName,
+		}, nil
 
 	case strings.HasPrefix(spec.Source, "github:"):
 		repo := strings.TrimPrefix(spec.Source, "github:")

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -14,14 +14,15 @@ type SharedData struct {
 }
 
 type Options struct {
-	InstanceDir string
-	DryRun      bool
-	Force       bool
-	Latest      bool
-	Concurrency int
-	GithubToken string
-	CacheDir    string
-	NoCache     bool
+	InstanceDir    string
+	DryRun         bool
+	Force          bool
+	Latest         bool
+	Concurrency    int
+	GithubToken    string
+	CurseForgeKey  string
+	CacheDir       string
+	NoCache        bool
 	// Shared optionally supplies pre-fetched manifest and assets DB.
 	// When non-nil, Run skips those network fetches.
 	Shared *SharedData

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -28,7 +28,7 @@ func normalizeRunOptions(opts Options) Options {
 
 func logRunStart(opts Options) {
 	logging.Debugf(
-		"Verbose: update start instance=%q dry-run=%t force=%t latest=%t concurrency=%d no-cache=%t cache-dir=%q github-token=%t\n",
+		"Verbose: update start instance=%q dry-run=%t force=%t latest=%t concurrency=%d no-cache=%t cache-dir=%q github-token=%t curseforge-key=%t\n",
 		opts.InstanceDir,
 		opts.DryRun,
 		opts.Force,
@@ -37,6 +37,7 @@ func logRunStart(opts Options) {
 		opts.NoCache,
 		opts.CacheDir,
 		opts.GithubToken != "",
+		opts.CurseForgeKey != "",
 	)
 }
 
@@ -173,7 +174,7 @@ func resolveConfiguredExtras(ctx context.Context, state *config.LocalState, db *
 	for _, name := range slices.Sorted(maps.Keys(state.ExtraMods)) {
 		spec := state.ExtraMods[name]
 		logging.Debugf("Verbose: resolving extra mod %s source=%q version=%q side=%q\n", name, spec.Source, spec.Version, spec.Side)
-		resolved, dlInfo, err := resolveExtraMod(ctx, name, spec, db, opts.GithubToken, opts.Latest)
+		resolved, dlInfo, err := resolveExtraMod(ctx, name, spec, db, opts.GithubToken, opts.CurseForgeKey, opts.Latest)
 		if err != nil {
 			unresolvedExtras = append(unresolvedExtras, fmt.Sprintf("%s (%v)", name, err))
 			logging.Debugf("Verbose: failed resolving extra mod %s: %v\n", name, err)


### PR DESCRIPTION
## Summary

- Adds a new `internal/curseforge` package: API client for CurseForge v1 with full `httptest`-based test coverage
- Two source formats for `extra add --source`:
  - `curseforge:12345` — resolves the latest release file for the given project
  - `curseforge:12345/67890` — pins a specific file ID
- New `--curseforge-key` flag (env: `CURSEFORGE_API_KEY`) threads through `cmd/root.go` → `updater.Options.CurseForgeKey` → `resolveExtraMod()`
- Handles mods with a null `downloadUrl` via the `/download-url` endpoint
- Fixed `GTNHGameVersion` to `"1.7.10"` (GTNH targets 1.7.10, not 1.12.2)
- README updated with CurseForge `extra add` examples and API key docs

## Test plan

- [ ] `go build ./...` — compiles cleanly
- [ ] `go test ./...` — all tests pass, including new `internal/curseforge` suite
- [ ] `gtnh-daily-updater extra add TestMod --source curseforge:12345` — validates source format
- [ ] `gtnh-daily-updater extra add TestMod --source curseforge:abc` — rejects invalid project ID
- [ ] Set `CURSEFORGE_API_KEY` and run `update` with a curseforge extra — downloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)