### PR TITLE
Update config to latest non-pre version when --latest is passed

### DIFF
--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -82,6 +82,10 @@ func (db *AssetsDB) buildIndex() {
 		})
 		db.modIndex[db.Mods[i].Name] = &db.Mods[i]
 	}
+	// Sort config versions by semver descending so newest is first
+	slices.SortFunc(db.Config.Versions, func(a, b VersionAsset) int {
+		return semver.Compare(b.VersionTag, a.VersionTag)
+	})
 }
 
 // LookupMod finds a mod by name in the index.
@@ -252,6 +256,18 @@ func (db *AssetsDB) LatestNonPreVersion(modName string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no stable non-pre version found for mod %q", modName)
+}
+
+// LatestNonPreConfigVersion returns the latest non-prerelease config version tag,
+// filtering out both the Prerelease flag and "-pre" suffixed version tags.
+// Returns empty string if no non-prerelease version is found.
+func (db *AssetsDB) LatestNonPreConfigVersion() string {
+	for _, v := range db.Config.Versions {
+		if !v.Prerelease && !strings.HasSuffix(strings.ToLower(strings.TrimSpace(v.VersionTag)), "-pre") {
+			return v.VersionTag
+		}
+	}
+	return ""
 }
 
 // ResolveConfigDownload finds the download URL for a config version.

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -46,18 +46,25 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 		resolveLatestVersions(ctx, db, changes, extraDownloads, latestDownloads, opts)
 	}
 
+	effectiveConfigVersion := m.Config
+	if opts.Latest {
+		if lv := db.LatestNonPreConfigVersion(); lv != "" {
+			effectiveConfigVersion = lv
+		}
+	}
+
 	added, removed, updated, unchanged := diff.Summary(changes)
 	logging.Debugf("Verbose: diff summary added=%d removed=%d updated=%d unchanged=%d\n", added, removed, updated, unchanged)
 	result := &UpdateResult{
 		OldVersion: state.ConfigVersion,
-		NewVersion: m.Config,
+		NewVersion: effectiveConfigVersion,
 		Added:      added,
 		Removed:    removed,
 		Updated:    updated,
 		Unchanged:  unchanged,
 	}
 
-	if !opts.Force && !opts.DryRun && result.Added == 0 && result.Removed == 0 && result.Updated == 0 && state.ConfigVersion == m.Config {
+	if !opts.Force && !opts.DryRun && result.Added == 0 && result.Removed == 0 && result.Updated == 0 && state.ConfigVersion == effectiveConfigVersion {
 		logging.Infoln("Already up to date.")
 		return result, nil
 	}
@@ -87,10 +94,10 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	if err := updateLwjgl3ifyIfNeeded(ctx, changes, state.Side, opts, rollback); err != nil {
 		return nil, err
 	}
-	if err := mergeConfigsIfNeeded(ctx, state, m, gameDir, db, opts, result, rollback); err != nil {
+	if err := mergeConfigsIfNeeded(ctx, state, m, gameDir, db, opts, result, rollback, effectiveConfigVersion); err != nil {
 		return nil, err
 	}
-	if err := persistUpdatedState(state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback); err != nil {
+	if err := persistUpdatedState(state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion); err != nil {
 		return nil, err
 	}
 

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -336,13 +336,13 @@ func updateLwjgl3ifyIfNeeded(ctx context.Context, changes []diff.ModChange, side
 	return nil
 }
 
-func mergeConfigsIfNeeded(ctx context.Context, state *config.LocalState, m *manifest.DailyManifest, gameDir string, db *assets.AssetsDB, opts Options, result *UpdateResult, rollback func(error) error) error {
-	if state.ConfigVersion == m.Config {
+func mergeConfigsIfNeeded(ctx context.Context, state *config.LocalState, m *manifest.DailyManifest, gameDir string, db *assets.AssetsDB, opts Options, result *UpdateResult, rollback func(error) error, configVersion string) error {
+	if state.ConfigVersion == configVersion {
 		return nil
 	}
 
 	logging.Infoln("Merging configs...")
-	mergeResult, err := configmerge.MergeConfigs(ctx, gameDir, state.ConfigHashes, state.ConfigVersion, db, m.Config, opts.GithubToken)
+	mergeResult, err := configmerge.MergeConfigs(ctx, gameDir, state.ConfigHashes, state.ConfigVersion, db, configVersion, opts.GithubToken)
 	if err != nil {
 		return rollback(fmt.Errorf("config merge failed: %w", err))
 	}
@@ -354,7 +354,7 @@ func mergeConfigsIfNeeded(ctx context.Context, state *config.LocalState, m *mani
 	return nil
 }
 
-func persistUpdatedState(state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error) error {
+func persistUpdatedState(state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error, configVersion string) error {
 	for _, c := range changes {
 		switch c.Type {
 		case diff.Added, diff.Updated:
@@ -373,7 +373,7 @@ func persistUpdatedState(state *config.LocalState, changes []diff.ModChange, m *
 	}
 	logging.Debugf("Verbose: updated in-memory state mods=%d\n", len(state.Mods))
 
-	state.ConfigVersion = m.Config
+	state.ConfigVersion = configVersion
 	state.ManifestDate = m.LastUpdated
 	state.Mode = mode
 


### PR DESCRIPTION
## Summary

- When `--latest` is active, the config ZIP is now resolved to the newest non-prerelease version from the assets DB rather than always using the manifest-pinned `Config` field — consistent with how mods are handled in `--latest` mode
- `buildIndex()` now sorts `db.Config.Versions` by semver descending (mirrors existing mod version sorting)
- New `AssetsDB.LatestNonPreConfigVersion()` returns the first config version that has neither `Prerelease: true` nor a `-pre` suffix
- `effectiveConfigVersion` is computed in `Run()` and threaded through `mergeConfigsIfNeeded` and `persistUpdatedState` via a new `configVersion string` parameter, replacing the hard-coded `m.Config` references

## Test plan

- [x] `go build` compiles cleanly
- [x] `go vet ./...` no warnings
- [x] `go test ./...` all tests pass
- [ ] Manual: run with `--latest --dry-run` and confirm the config target version in logs is the latest from the assets DB, not the manifest-pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)