### PR TITLE
Use manifest date for status current/latest display

### DIFF
--- a/internal/updater/status.go
+++ b/internal/updater/status.go
@@ -39,9 +39,8 @@ func Status(ctx context.Context, instanceDir, githubToken string) error {
 
 	logging.Infof("Side:      %s\n", state.Side)
 	logging.Infof("Mode:      %s\n", mode)
-	logging.Infof("Current:   %s\n", state.ConfigVersion)
-	logging.Infof("Latest:    %s\n", m.Config)
-	logging.Infof("Updated:   %s\n", m.LastUpdated)
+	logging.Infof("Current:   %s\n", state.ManifestDate)
+	logging.Infof("Latest:    %s\n", m.LastUpdated)
 
 	if m.LastUpdated == state.ManifestDate {
 		logging.Infoln("\nAlready up to date.")


### PR DESCRIPTION
## Summary
- `status` was showing `config_version` as the "Current"/"Latest" indicator, but config version only changes when pack configs update — not on every manifest update
- This meant mods could change without the config version bumping, making the status output show identical "Current" and "Latest" values even when updates were available
- Now uses `manifest_date` / `m.LastUpdated` for the primary display, which is exactly what the up-to-date check already compares

## Test plan
- [ ] Run `status` on an instance that is behind — verify "Current" and "Latest" show different dates
- [ ] Run `status` on an up-to-date instance — verify both show the same date and "Already up to date." is printed
- [ ] Config version change (if applicable) still appears under "Changes available" when configs differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)