### PR TITLE
Make --config required for init and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ CLI tool for keeping an existing GregTech: New Horizons instance up to date with
 It tracks installed mods, downloads changes, and merges tracked pack files/config updates while preserving user edits when possible.
 
 ## Warning
-This is only used for updating from a daily to a daily or an experimental to an experimental
+This is only used for updating from a daily to a daily or an experimental to an experimental  
 If coming from the old gtnh-nightly-updater jar, it is best to start from scratch and manually copy any user added mods and config changes (as well as the other folders on the wiki page about updating)
 
+Always make a full instance backup before first using this program
 
 ## Features
 
 - Initializes tracking from an existing instance (`init`)
 - Updates mods to manifest-pinned versions (`update`)
-- Optional `--latest` mode to use newest non-pre releases when available
+- Optional `--latest` mode to use newest non-pre releases when available (Only use if you know what you are doing)
 - Merges tracked pack files/configs between versions (writes `*.packnew` on conflicts)
 - Supports excluded mods and user-defined extra mods
 - Supports named profiles and multi-profile batch updates (`update-all`)
@@ -44,24 +45,25 @@ go install .
 
 1. Initialize state for an existing instance:
 
-```bash
-gtnh-daily-updater init \
-  --instance-dir "/path/to/instance" \
-  --side client
-```
-
-Use `--side server` for servers. For experimental packs:
-
-```bash
-gtnh-daily-updater init --instance-dir "/path/to/instance" --side client --mode experimental
-```
-
-If your instance is older than latest, pass the installed config version:
+Note: You MUST pass the current config version your instance has. It will not work correctly otherwise.  
+Config versions can be found at https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/releases.
 
 ```bash
 gtnh-daily-updater init \
   --instance-dir "/path/to/instance" \
   --side client \
+  --config 2.9.0-nightly-2026-02-10
+```
+
+Use `--side server` for servers.
+
+For experimental packs:
+
+```bash
+gtnh-daily-updater init \
+  --instance-dir "/path/to/instance" \
+  --side client \
+  --mode experimental \
   --config 2.9.0-nightly-2026-02-10
 ```
 
@@ -120,6 +122,8 @@ Add extra mods from GitHub releases:
 ```bash
 gtnh-daily-updater extra add SomeMod --source github:Owner/Repo
 ```
+
+Note: Adding CurseForge extra mods requires a CurseForge API key  
 
 Add extra mods from CurseForge (latest release file):
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,21 +16,25 @@ var initCmd = &cobra.Command{
 	Long: `Scans the mods/ directory and matches jar filenames against the GTNH assets
 database to determine what's currently installed.
 
-If your instance is out of date, optionally specify --config to indicate
-which nightly config version is installed (e.g. "2.9.0-nightly-2026-02-10").
-If omitted, the latest config version is assumed.
+--config is required. Specify the config version your instance is at
+(e.g. "2.9.0-nightly-2026-02-10"). Config versions can be found at
+<https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/releases>
+and they do not always match the date of the daily.
 
 Use --mode experimental for experimental pack instances.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if installSide == "" {
 			return wrapUsageError(fmt.Errorf("--side is required (client or server)"))
 		}
+		if configVersion == "" {
+			return wrapUsageError(fmt.Errorf("--config is required (e.g. 2.9.0-nightly-2026-02-10); see <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/releases>; will not always be the day the daily was mode"))
+		}
 		return updater.Init(context.Background(), instanceDir, installSide, configVersion, mode, getGithubToken())
 	},
 }
 
 func init() {
-	initCmd.Flags().StringVar(&configVersion, "config", "", "Current config version (e.g. 2.9.0-nightly-2026-02-10). Defaults to latest if omitted.")
+	initCmd.Flags().StringVar(&configVersion, "config", "", "Current config version (e.g. 2.9.0-nightly-2026-02-10). Required.")
 	initCmd.Flags().StringVar(&installSide, "side", "", "Install side: client or server")
 	initCmd.Flags().StringVar(&mode, "mode", "", "Pack mode to use: daily or experimental (default: infer from --config, else daily)")
 	rootCmd.AddCommand(initCmd)

--- a/internal/updater/init.go
+++ b/internal/updater/init.go
@@ -91,14 +91,6 @@ func Init(ctx context.Context, instanceDir, side, configVersion, mode, githubTok
 		return fmt.Errorf("scanning mods directory: %w", err)
 	}
 
-	// Determine config version
-	if configVersion == "" {
-		// Default to latest manifest's config version, but warn the user
-		configVersion = m.Config
-		logging.Infof("  No --config-version specified, assuming latest: %s\n", configVersion)
-		logging.Infoln("  If your instance is out of date, specify the correct version with --config-version")
-	}
-
 	// Hash files tracked by this modpack version (config + other managed files).
 	logging.Infoln("Hashing tracked modpack files...")
 	hashes, err := configmerge.ComputeTrackedFileHashes(ctx, gameDir, db, configVersion, githubToken)


### PR DESCRIPTION
--config is now mandatory for `gtnh-daily-updater init` rather than defaulting to the latest config version, preventing silent misconfiguration when initializing from an older instance. README and help text updated to reflect this and clarify where config versions can be found.