### PR TITLE
Sanitize filenames for cross-OS compatibility and evict old cache files

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 )
 
@@ -136,16 +138,26 @@ func downloadFileWithRetryURL(ctx context.Context, dl Download, destDir, githubT
 }
 
 func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheDir string) error {
-	destPath := filepath.Join(destDir, dl.Filename)
+	safeFilename := fileutil.SanitizeFilename(dl.Filename)
+	safeModName := fileutil.SanitizeFilename(dl.ModName)
+	destPath := filepath.Join(destDir, safeFilename)
 	logging.Debugf("Verbose: download start mod=%s filename=%s url=%s\n", dl.ModName, dl.Filename, dl.URL)
 
 	// Check cache first
 	if cacheDir != "" {
-		modCacheDir := filepath.Join(cacheDir, dl.ModName)
-		cachePath := filepath.Join(modCacheDir, dl.Filename)
+		modCacheDir := filepath.Join(cacheDir, safeModName)
+		cachePath := filepath.Join(modCacheDir, safeFilename)
 		if _, err := os.Stat(cachePath); err == nil {
 			logging.Debugf("Verbose: cache hit mod=%s file=%s\n", dl.ModName, dl.Filename)
 			return copyFile(cachePath, destPath)
+		}
+		// Fall back to old unsanitized cache path for backwards compatibility
+		oldCachePath := filepath.Join(cacheDir, dl.ModName, dl.Filename)
+		if oldCachePath != cachePath {
+			if _, err := os.Stat(oldCachePath); err == nil {
+				logging.Debugf("Verbose: cache hit (legacy path) mod=%s file=%s\n", dl.ModName, dl.Filename)
+				return copyFile(oldCachePath, destPath)
+			}
 		}
 		logging.Debugf("Verbose: cache miss mod=%s file=%s\n", dl.ModName, dl.Filename)
 	}
@@ -173,11 +185,11 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 
 	// If caching, download to cache first, then copy to dest
 	if cacheDir != "" {
-		modCacheDir := filepath.Join(cacheDir, dl.ModName)
+		modCacheDir := filepath.Join(cacheDir, safeModName)
 		if err := os.MkdirAll(modCacheDir, 0755); err != nil {
 			return fmt.Errorf("creating cache dir for %s: %w", dl.ModName, err)
 		}
-		cachePath := filepath.Join(modCacheDir, dl.Filename)
+		cachePath := filepath.Join(modCacheDir, safeFilename)
 		cacheTmp := cachePath + ".tmp"
 
 		f, err := os.Create(cacheTmp)
@@ -201,6 +213,7 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 			return fmt.Errorf("finalizing cache for %s: %w", dl.Filename, err)
 		}
 
+		evictOldCacheFiles(modCacheDir, 5)
 		return copyFile(cachePath, destPath)
 	}
 
@@ -308,4 +321,48 @@ func downloadToFileOnce(ctx context.Context, url, destPath, githubToken string, 
 	}
 
 	return nil
+}
+
+// evictOldCacheFiles removes the oldest files in dir, keeping only the newest
+// keep entries. Errors are logged but not returned since eviction is best-effort.
+func evictOldCacheFiles(dir string, keep int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	type fileEntry struct {
+		name    string
+		modTime time.Time
+	}
+
+	var files []fileEntry
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, fileEntry{name: e.Name(), modTime: info.ModTime()})
+	}
+
+	if len(files) <= keep {
+		return
+	}
+
+	// Sort newest first
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime.After(files[j].modTime)
+	})
+
+	for _, f := range files[keep:] {
+		path := filepath.Join(dir, f.name)
+		if err := os.Remove(path); err != nil {
+			logging.Debugf("Verbose: failed to evict cached file %s: %v\n", path, err)
+		} else {
+			logging.Debugf("Verbose: evicted old cached file %s\n", path)
+		}
+	}
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -8,6 +8,26 @@ import (
 	"strings"
 )
 
+// SanitizeFilename removes or replaces characters that are invalid in
+// filenames on Windows, macOS, or Linux. Only allows [a-zA-Z0-9._-],
+// converts spaces to hyphens, and drops everything else.
+func SanitizeFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '-' || r == '.' || r == '_':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		default:
+			// skip invalid characters
+		}
+	}
+	return b.String()
+}
+
 // CopyFile copies a single file from src to dst, preserving permissions.
 // Parent directories of dst are created as needed.
 func CopyFile(src, dst string) error {

--- a/internal/maven/maven.go
+++ b/internal/maven/maven.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/semver"
 )
 
@@ -126,20 +127,7 @@ func latestStableVersion(versions []string, release string) string {
 // SanitizeComponent removes or replaces characters invalid in Maven artifact
 // paths or filenames.
 func SanitizeComponent(s string) string {
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
-			b.WriteRune(r)
-		case r == '-' || r == '.' || r == '_':
-			b.WriteRune(r)
-		case r == ' ':
-			b.WriteRune('-')
-		default:
-			// skip invalid characters
-		}
-	}
-	return b.String()
+	return fileutil.SanitizeFilename(s)
 }
 
 func MavenFilename(modName, version string) string {


### PR DESCRIPTION
Move filename sanitization logic to fileutil.SanitizeFilename and apply it in the downloader for both filenames and mod cache directory names. Maven's SanitizeComponent now delegates to the shared implementation.

The downloader falls back to unsanitized cache paths for backwards compatibility with existing caches, and evicts old cached files per mod keeping only the 5 most recent.