### PR TITLE
Add Windows manifest to prevent UAC admin elevation prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Generate Windows manifest
+        if: matrix.goos == 'windows'
+        run: |
+          go install github.com/akavel/rsrc@latest
+          rsrc -manifest gtnh-daily-updater.manifest -arch amd64 -o rsrc_windows_amd64.syso
+
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Generate Windows manifest
         if: matrix.goos == 'windows'
         run: |
-          go install github.com/akavel/rsrc@latest
-          rsrc -manifest gtnh-daily-updater.manifest -arch amd64 -o rsrc_windows_amd64.syso
+          go install github.com/akavel/rsrc@v0.10.2
+          rsrc -manifest gtnh-daily-updater.manifest -arch "${{ matrix.goarch }}" -o "rsrc_windows_${{ matrix.goarch }}.syso"
 
       - name: Build
         env:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On Windows, the build process generates a manifest file that prevents unnecessar
 
 ```powershell
 # Install rsrc (one-time setup)
-go install github.com/akavel/rsrc@latest
+go install github.com/akavel/rsrc@v0.10.2
 
 # Generate the Windows manifest resource
 rsrc -manifest gtnh-daily-updater.manifest -arch amd64 -o rsrc_windows_amd64.syso
@@ -63,11 +63,11 @@ rsrc -manifest gtnh-daily-updater.manifest -arch amd64 -o rsrc_windows_amd64.sys
 go build -o gtnh-daily-updater.exe .
 ```
 
-Or for 32-bit Windows:
+For another Windows architecture (for example, 386), keep `GOARCH` and `rsrc -arch` aligned:
 
 ```powershell
-rsrc -manifest gtnh-daily-updater.manifest -arch 386 -o rsrc_windows_386.syso
-set GOARCH=386
+$env:GOARCH = "386"
+rsrc -manifest gtnh-daily-updater.manifest -arch $env:GOARCH -o "rsrc_windows_$($env:GOARCH).syso"
 go build -o gtnh-daily-updater.exe .
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Or install into your Go bin:
 go install .
 ```
 
+**Building on Windows** (to avoid UAC admin prompts):
+
+On Windows, the build process generates a manifest file that prevents unnecessary UAC prompts. To build with the manifest:
+
+```powershell
+# Install rsrc (one-time setup)
+go install github.com/akavel/rsrc@latest
+
+# Generate the Windows manifest resource
+rsrc -manifest gtnh-daily-updater.manifest -arch amd64 -o rsrc_windows_amd64.syso
+
+# Build the executable (go will automatically link the .syso file)
+go build -o gtnh-daily-updater.exe .
+```
+
+Or for 32-bit Windows:
+
+```powershell
+rsrc -manifest gtnh-daily-updater.manifest -arch 386 -o rsrc_windows_386.syso
+set GOARCH=386
+go build -o gtnh-daily-updater.exe .
+```
+
 ## Quick Start
 
 1. Initialize state for an existing instance:

--- a/gtnh-daily-updater.manifest
+++ b/gtnh-daily-updater.manifest
@@ -2,8 +2,8 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
     version="1.0.0.0"
-    processorArchitecture="amd64"
-    name="gtnh-daily-updater"
+    processorArchitecture="*"
+    name="Caedis.GtnhDailyUpdater"
     type="win32"
   />
   <description>GTNH Daily Updater - CLI tool for keeping GTNH instances up to date</description>

--- a/gtnh-daily-updater.manifest
+++ b/gtnh-daily-updater.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="amd64"
+    name="gtnh-daily-updater"
+    type="win32"
+  />
+  <description>GTNH Daily Updater - CLI tool for keeping GTNH instances up to date</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
This PR adds a Windows manifest to prevent the executable from requesting administrator privileges on startup.

## Changes
- Add gtnh-daily-updater.manifest with execution level set to asInvoker
- Integrate rsrc into release workflow to embed manifest into Windows builds
- Update README with Windows build instructions

## Why
The Windows executable was triggering an elevation prompt. Embedding an explicit manifest with asInvoker prevents unnecessary UAC prompts while preserving normal user execution.