### PR TITLE
feat(self-update): add startup check and self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Always make a full instance backup before first using this program
 - Supports excluded mods and user-defined extra mods
 - Supports named profiles and multi-profile batch updates (`update-all`)
 - Download caching and configurable concurrency
+- Optional startup self-update check with SHA256-verified `self-update` command
 
 ## Requirements
 
@@ -128,6 +129,7 @@ gtnh-daily-updater update --instance-dir "/path/to/instance"
 - `exclude add|remove|list`: skip selected manifest mods
 - `extra add|remove|list`: manage non-manifest mods
 - `profile create|list|show|delete`: manage reusable option sets
+- `self-update`: download and install the latest release after SHA256 verification
 
 Inspect all options:
 
@@ -256,6 +258,33 @@ Or pass per command:
 ```bash
 gtnh-daily-updater update --curseforge-key your_key_here
 ```
+
+## Self-Update
+
+The tool can check GitHub for newer releases at startup and install them on demand. Both behaviors are off by default.
+
+A global config file is created on first run at:
+
+- Linux: `${XDG_CONFIG_HOME:-~/.config}/gtnh-daily-updater/config.toml`
+- macOS: `~/Library/Application Support/gtnh-daily-updater/config.toml`
+- Windows: `%AppData%\gtnh-daily-updater\config.toml`
+
+```toml
+auto_update_check = false
+include_prereleases = false
+```
+
+When `auto_update_check = false` (default), the tool prints a one-line hint pointing to the config file. When `true`, each invocation queries GitHub (3s timeout, silent on failure) and prints a notice if a newer release is available.
+
+Install the latest release:
+
+```bash
+gtnh-daily-updater self-update            # prompts for confirmation
+gtnh-daily-updater self-update --yes      # skip prompt (non-interactive)
+gtnh-daily-updater self-update --prerelease
+```
+
+The downloaded zip's SHA256 is verified against the digest published by the GitHub release API before the running binary is replaced. On Windows, the previous binary is left as `<exe>.old` and removed on next startup.
 
 ## Development
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
+	"github.com/caedis/gtnh-daily-updater/internal/globalconfig"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/paths"
 	"github.com/caedis/gtnh-daily-updater/internal/profile"
+	"github.com/caedis/gtnh-daily-updater/internal/selfupdate"
 	"github.com/spf13/cobra"
 )
 
@@ -80,8 +84,38 @@ var rootCmd = &cobra.Command{
 		if err := logging.SetOutputFile(logFile); err != nil {
 			return fmt.Errorf("opening log file %q: %w", logFile, err)
 		}
+
+		maybeCheckForUpdate(cmd)
 		return nil
 	},
+}
+
+// maybeCheckForUpdate runs the startup self-update check. It is intentionally
+// best-effort and silent on failure. Skipped for the self-update command
+// itself (which performs its own check).
+func maybeCheckForUpdate(cmd *cobra.Command) {
+	selfupdate.CleanupOldExe()
+
+	if cmd != nil && cmd.Name() == selfUpdateCmdName {
+		return
+	}
+
+	cfg, _ := globalconfig.Load()
+	if !cfg.AutoUpdateCheck {
+		_ = globalconfig.WriteDefaultIfMissing()
+		if p, err := globalconfig.Path(); err == nil {
+			logging.Infof("Update check disabled. Set auto_update_check = true in %s to enable.\n", p)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	info, newer, err := selfupdate.CheckLatest(ctx, version, cfg.IncludePrereleases)
+	if err != nil || !newer || info == nil {
+		return
+	}
+	logging.Infof("Update available: %s → %s. Run `gtnh-daily-updater self-update` to install.\n", version, info.Tag)
 }
 
 func Execute() {

--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/caedis/gtnh-daily-updater/internal/globalconfig"
+	"github.com/caedis/gtnh-daily-updater/internal/logging"
+	"github.com/caedis/gtnh-daily-updater/internal/paths"
+	"github.com/caedis/gtnh-daily-updater/internal/selfupdate"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+const selfUpdateCmdName = "self-update"
+
+var (
+	selfUpdateYes        bool
+	selfUpdatePrerelease bool
+)
+
+var selfUpdateCmd = &cobra.Command{
+	Use:   selfUpdateCmdName,
+	Short: "Download and install the latest release of this tool",
+	Long: `Check GitHub for the latest release, verify its SHA256, and replace
+the running binary. Prompts for confirmation unless --yes is given.`,
+	Args: usageArgs(cobra.NoArgs),
+	RunE: runSelfUpdate,
+}
+
+func init() {
+	selfUpdateCmd.Flags().BoolVarP(&selfUpdateYes, "yes", "y", false, "Skip the confirmation prompt")
+	selfUpdateCmd.Flags().BoolVar(&selfUpdatePrerelease, "prerelease", false, "Include pre-release versions")
+	rootCmd.AddCommand(selfUpdateCmd)
+}
+
+func runSelfUpdate(cmd *cobra.Command, _ []string) error {
+	includePre := selfUpdatePrerelease
+	if !cmd.Flags().Changed("prerelease") {
+		if cfg, err := globalconfig.Load(); err == nil {
+			includePre = cfg.IncludePrereleases
+		}
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	info, newer, err := selfupdate.CheckLatest(ctx, version, includePre)
+	if err != nil {
+		return fmt.Errorf("checking latest release: %w", err)
+	}
+	if !newer {
+		logging.Infof("Already up to date (%s).\n", version)
+		return nil
+	}
+
+	if !selfUpdateYes {
+		ok, err := confirm(fmt.Sprintf("Update %s → %s. Proceed? [y/N]: ", version, info.Tag))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			logging.Infof("Aborted.\n")
+			return nil
+		}
+	}
+
+	cacheDir, err := paths.CacheDir()
+	if err != nil {
+		return fmt.Errorf("resolving cache dir: %w", err)
+	}
+	workDir := filepath.Join(cacheDir, "selfupdate")
+	zipPath := filepath.Join(workDir, info.AssetName)
+	binPath := filepath.Join(workDir, selfupdate.BinaryName()+".new")
+
+	logging.Infof("Downloading %s...\n", info.AssetURL)
+	if err := selfupdate.Download(ctx, info, zipPath); err != nil {
+		return fmt.Errorf("downloading: %w", err)
+	}
+
+	if err := selfupdate.VerifySHA256(zipPath, info.SHA256); err != nil {
+		_ = os.Remove(zipPath)
+		return fmt.Errorf("verifying download: %w", err)
+	}
+
+	if err := selfupdate.ExtractBinary(zipPath, binPath); err != nil {
+		return fmt.Errorf("extracting: %w", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving current executable: %w", err)
+	}
+	if err := selfupdate.Replace(exe, binPath); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+	_ = os.Remove(zipPath)
+
+	logging.Infof("Updated to %s.\n", info.Tag)
+	return nil
+}
+
+func confirm(prompt string) (bool, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false, fmt.Errorf("non-interactive stdin; pass --yes to skip prompt")
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	ans := strings.ToLower(strings.TrimSpace(line))
+	return ans == "y" || ans == "yes", nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.25.6
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.43.0
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,4 +9,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -22,7 +22,8 @@ type Release struct {
 type ReleaseAsset struct {
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
-	URL                string `json:"url"` // API URL for authenticated downloads
+	URL                string `json:"url"`    // API URL for authenticated downloads
+	Digest             string `json:"digest"` // e.g. "sha256:abcdef..."
 }
 
 // LatestResult holds the result of a GitHub latest-release lookup.
@@ -36,6 +37,14 @@ type LatestResult struct {
 const releasesPerPage = 25
 
 var githubHTTPClient = http.DefaultClient
+
+// SetHTTPClient swaps the package-level HTTP client used for GitHub API calls
+// and returns the previous client. Intended for tests.
+func SetHTTPClient(c *http.Client) *http.Client {
+	old := githubHTTPClient
+	githubHTTPClient = c
+	return old
+}
 
 // PickPrimaryJar selects the primary mod jar from a list of GitHub release assets.
 // It looks for a .jar file whose name ends with "-{version}.jar", which excludes
@@ -160,6 +169,13 @@ func selectLatestResult(releases []Release, token string, allowPre bool) (*Lates
 		return nil, fmt.Errorf("no non-prerelease with .jar asset found")
 	}
 	return best, nil
+}
+
+// FetchReleasesRaw fetches the recent releases for repo without filtering.
+// Intended for callers that need full asset metadata (e.g. self-update).
+func FetchReleasesRaw(ctx context.Context, repo, token string) ([]Release, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=%d", repo, releasesPerPage)
+	return fetchReleases(ctx, apiURL, token)
 }
 
 // FetchLatestReleaseTag returns the latest tag from a GitHub repo.

--- a/internal/globalconfig/config.go
+++ b/internal/globalconfig/config.go
@@ -1,0 +1,78 @@
+// Package globalconfig manages the user-level TOML config file controlling
+// non-instance-specific behavior (currently: self-update checking).
+package globalconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/caedis/gtnh-daily-updater/internal/paths"
+)
+
+// Config is the global user configuration.
+type Config struct {
+	AutoUpdateCheck    bool `toml:"auto_update_check"`
+	IncludePrereleases bool `toml:"include_prereleases"`
+}
+
+const fileName = "config.toml"
+
+const defaultTemplate = `# gtnh-daily-updater global config
+# Set auto_update_check = true to check GitHub for new releases at startup.
+# When a newer release is found, run "gtnh-daily-updater self-update" to install it.
+
+auto_update_check = false
+include_prereleases = false
+`
+
+// Path returns the absolute path to the global config file.
+func Path() (string, error) {
+	dir, err := paths.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fileName), nil
+}
+
+// Load reads the global config file. A missing file yields a zero-value Config
+// and a nil error.
+func Load() (Config, error) {
+	var cfg Config
+	p, err := Path()
+	if err != nil {
+		return cfg, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("reading %s: %w", p, err)
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parsing %s: %w", p, err)
+	}
+	return cfg, nil
+}
+
+// WriteDefaultIfMissing writes a commented default config file when one does
+// not already exist. Errors are returned but callers may safely ignore them.
+func WriteDefaultIfMissing() error {
+	p, err := Path()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(p); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(defaultTemplate), 0o644)
+}

--- a/internal/globalconfig/config_test.go
+++ b/internal/globalconfig/config_test.go
@@ -1,0 +1,84 @@
+package globalconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func setConfigHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("AppData", dir)
+	case "darwin":
+		t.Setenv("HOME", dir)
+	default:
+		t.Setenv("XDG_CONFIG_HOME", dir)
+	}
+	return dir
+}
+
+func TestLoadMissingReturnsDefaults(t *testing.T) {
+	setConfigHome(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.AutoUpdateCheck || cfg.IncludePrereleases {
+		t.Fatalf("expected zero-value config, got %+v", cfg)
+	}
+}
+
+func TestWriteDefaultIfMissingCreatesFile(t *testing.T) {
+	setConfigHome(t)
+	if err := WriteDefaultIfMissing(); err != nil {
+		t.Fatalf("WriteDefaultIfMissing: %v", err)
+	}
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("default template is empty")
+	}
+
+	// Second call is a no-op.
+	info1, _ := os.Stat(p)
+	if err := WriteDefaultIfMissing(); err != nil {
+		t.Fatalf("second WriteDefaultIfMissing: %v", err)
+	}
+	info2, _ := os.Stat(p)
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Fatal("WriteDefaultIfMissing overwrote existing file")
+	}
+}
+
+func TestLoadParsesValues(t *testing.T) {
+	setConfigHome(t)
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := "auto_update_check = true\ninclude_prereleases = true\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.AutoUpdateCheck || !cfg.IncludePrereleases {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -1,0 +1,156 @@
+package selfupdate
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/caedis/gtnh-daily-updater/internal/downloader"
+)
+
+// Download fetches the release asset zip to destZip.
+func Download(ctx context.Context, info *LatestInfo, destZip string) error {
+	if err := os.MkdirAll(filepath.Dir(destZip), 0o755); err != nil {
+		return fmt.Errorf("preparing download dir: %w", err)
+	}
+	return downloader.DownloadToFile(ctx, info.AssetURL, destZip, "", false)
+}
+
+// VerifySHA256 computes the SHA256 of path and compares it to expected (hex).
+func VerifySHA256(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing %s: %w", path, err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("sha256 mismatch: got %s want %s", got, expected)
+	}
+	return nil
+}
+
+// ExtractBinary opens zipPath, finds the binary entry, and writes it to dest.
+func ExtractBinary(zipPath, dest string) error {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("opening zip %s: %w", zipPath, err)
+	}
+	defer zr.Close()
+
+	want := BinaryName()
+	var entry *zip.File
+	for _, f := range zr.File {
+		base := filepath.Base(f.Name)
+		if strings.EqualFold(base, want) {
+			entry = f
+			break
+		}
+	}
+	if entry == nil {
+		return fmt.Errorf("zip %s does not contain %s", zipPath, want)
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		return fmt.Errorf("opening zip entry: %w", err)
+	}
+	defer rc.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, rc); err != nil {
+		out.Close()
+		return fmt.Errorf("writing %s: %w", dest, err)
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Replace swaps the running executable with newBinary. On Windows this renames
+// the current binary to <exe>.old (Windows allows renaming a running .exe but
+// not overwriting it). Callers should remove .old on the next startup.
+func Replace(currentExe, newBinary string) error {
+	currentExe, err := filepath.Abs(currentExe)
+	if err != nil {
+		return err
+	}
+	if resolved, err := filepath.EvalSymlinks(currentExe); err == nil {
+		currentExe = resolved
+	}
+
+	if runtime.GOOS == "windows" {
+		old := currentExe + ".old"
+		_ = os.Remove(old)
+		if err := os.Rename(currentExe, old); err != nil {
+			return fmt.Errorf("moving current exe: %w", err)
+		}
+		if err := os.Rename(newBinary, currentExe); err != nil {
+			// best-effort rollback
+			_ = os.Rename(old, currentExe)
+			return fmt.Errorf("installing new exe: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.Rename(newBinary, currentExe); err != nil {
+		// fall back to copy + rename for cross-device moves
+		if copyErr := copyFile(newBinary, currentExe+".new"); copyErr != nil {
+			return fmt.Errorf("installing new exe: %w (rename) / %w (copy)", err, copyErr)
+		}
+		if err := os.Rename(currentExe+".new", currentExe); err != nil {
+			return fmt.Errorf("installing new exe: %w", err)
+		}
+		_ = os.Remove(newBinary)
+	}
+	return nil
+}
+
+// CleanupOldExe removes the leftover <exe>.old from a prior Windows update.
+// Safe to call on any platform; no-op when the file does not exist.
+func CleanupOldExe() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	_ = os.Remove(exe + ".old")
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/selfupdate/apply_test.go
+++ b/internal/selfupdate/apply_test.go
@@ -1,0 +1,103 @@
+package selfupdate
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeZip(t *testing.T, dir string, entries map[string][]byte) (string, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zw.Create: %v", err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatalf("write entry: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zw.Close: %v", err)
+	}
+	path := filepath.Join(dir, "asset.zip")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return path, hex.EncodeToString(sum[:])
+}
+
+func TestVerifySHA256(t *testing.T) {
+	dir := t.TempDir()
+	path, sum := writeZip(t, dir, map[string][]byte{BinaryName(): []byte("hello")})
+
+	if err := VerifySHA256(path, sum); err != nil {
+		t.Fatalf("VerifySHA256: %v", err)
+	}
+	if err := VerifySHA256(path, "00"); err == nil {
+		t.Fatal("expected mismatch error")
+	}
+}
+
+func TestExtractBinary(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte("binary-bytes")
+	path, _ := writeZip(t, dir, map[string][]byte{BinaryName(): body})
+
+	dest := filepath.Join(dir, "out")
+	if err := ExtractBinary(path, dest); err != nil {
+		t.Fatalf("ExtractBinary: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("contents mismatch: %q", got)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Fatalf("binary not executable: %v", info.Mode())
+	}
+}
+
+func TestExtractBinaryMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	path, _ := writeZip(t, dir, map[string][]byte{"README.md": []byte("x")})
+	if err := ExtractBinary(path, filepath.Join(dir, "out")); err == nil {
+		t.Fatal("expected error for missing binary entry")
+	}
+}
+
+func TestReplace(t *testing.T) {
+	dir := t.TempDir()
+	current := filepath.Join(dir, "current")
+	if err := os.WriteFile(current, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile current: %v", err)
+	}
+	newBin := filepath.Join(dir, "new")
+	if err := os.WriteFile(newBin, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile new: %v", err)
+	}
+
+	if err := Replace(current, newBin); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	got, err := os.ReadFile(current)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("after replace contents=%q want %q", got, "new")
+	}
+}

--- a/internal/selfupdate/check.go
+++ b/internal/selfupdate/check.go
@@ -1,0 +1,103 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/caedis/gtnh-daily-updater/internal/github"
+	"github.com/caedis/gtnh-daily-updater/internal/semver"
+)
+
+// LatestInfo describes the newest release asset for this platform.
+type LatestInfo struct {
+	Tag       string
+	AssetName string
+	AssetURL  string
+	SHA256    string // hex-encoded, lowercase
+}
+
+// CheckLatest queries GitHub for the latest release of this tool and returns
+// info about the matching platform asset. The bool is true when the latest tag
+// is newer than currentVersion. If currentVersion is "dev" (unversioned build),
+// returns (info, false, nil) — info populated so callers can still self-update,
+// but startup notifier suppresses notice.
+func CheckLatest(ctx context.Context, currentVersion string, includePre bool) (*LatestInfo, bool, error) {
+	releases, err := github.FetchReleasesRaw(ctx, Repo, "")
+	if err != nil {
+		return nil, false, err
+	}
+
+	var best *github.Release
+	for i, rel := range releases {
+		tag := strings.TrimSpace(rel.TagName)
+		if tag == "" {
+			continue
+		}
+		if !includePre && (rel.Prerelease || semver.IsPreRelease(tag)) {
+			continue
+		}
+		if best == nil || semver.Compare(tag, best.TagName) > 0 {
+			best = &releases[i]
+		}
+	}
+	if best == nil {
+		return nil, false, fmt.Errorf("no release found for repo %s", Repo)
+	}
+
+	wantName := AssetName(strings.TrimPrefix(best.TagName, "v"))
+	asset := findAsset(best.Assets, wantName)
+	if asset == nil {
+		// fall back to matching with the tag as-is (in case tag has no v-prefix)
+		asset = findAsset(best.Assets, AssetName(best.TagName))
+	}
+	if asset == nil {
+		return nil, false, fmt.Errorf("release %s has no asset %q", best.TagName, wantName)
+	}
+
+	sha, err := extractSHA256(asset.Digest)
+	if err != nil {
+		return nil, false, fmt.Errorf("release %s asset %s: %w", best.TagName, asset.Name, err)
+	}
+
+	url := strings.TrimSpace(asset.BrowserDownloadURL)
+	if url == "" {
+		return nil, false, fmt.Errorf("release %s asset %s has no download URL", best.TagName, asset.Name)
+	}
+
+	info := &LatestInfo{
+		Tag:       best.TagName,
+		AssetName: asset.Name,
+		AssetURL:  url,
+		SHA256:    sha,
+	}
+
+	newer := isNewer(currentVersion, best.TagName)
+	return info, newer, nil
+}
+
+func findAsset(assets []github.ReleaseAsset, name string) *github.ReleaseAsset {
+	for i := range assets {
+		if strings.EqualFold(strings.TrimSpace(assets[i].Name), name) {
+			return &assets[i]
+		}
+	}
+	return nil
+}
+
+func extractSHA256(digest string) (string, error) {
+	d := strings.TrimSpace(digest)
+	const prefix = "sha256:"
+	if !strings.HasPrefix(strings.ToLower(d), prefix) {
+		return "", fmt.Errorf("missing or unsupported digest %q", digest)
+	}
+	return strings.ToLower(d[len(prefix):]), nil
+}
+
+func isNewer(current, latest string) bool {
+	c := strings.TrimSpace(current)
+	if c == "" || c == "dev" {
+		return false
+	}
+	return semver.Compare(latest, c) > 0
+}

--- a/internal/selfupdate/check_test.go
+++ b/internal/selfupdate/check_test.go
@@ -1,0 +1,158 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/github"
+)
+
+type rewriteHostTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t *rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = t.host
+	if t.rt != nil {
+		return t.rt.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func overrideGitHubClient(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	c := &http.Client{Transport: &rewriteHostTransport{host: parsed.Host, rt: server.Client().Transport}}
+	old := github.SetHTTPClient(c)
+	t.Cleanup(func() { github.SetHTTPClient(old) })
+}
+
+func TestCheckLatestPicksHighestSemver(t *testing.T) {
+	assetName := AssetName("1.2.3")
+	releases := []github.Release{
+		{
+			TagName: "1.2.3",
+			Assets: []github.ReleaseAsset{
+				{
+					Name:               assetName,
+					BrowserDownloadURL: "https://example.test/" + assetName,
+					Digest:             "sha256:abcdef0123456789",
+				},
+			},
+		},
+		{
+			TagName: "1.1.0",
+			Assets: []github.ReleaseAsset{
+				{
+					Name:               AssetName("1.1.0"),
+					BrowserDownloadURL: "https://example.test/old.zip",
+					Digest:             "sha256:000000",
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+	overrideGitHubClient(t, server)
+
+	info, newer, err := CheckLatest(context.Background(), "1.0.0", false)
+	if err != nil {
+		t.Fatalf("CheckLatest: %v", err)
+	}
+	if !newer {
+		t.Fatal("expected newer=true")
+	}
+	if info.Tag != "1.2.3" {
+		t.Fatalf("tag=%q want 1.2.3", info.Tag)
+	}
+	if info.SHA256 != "abcdef0123456789" {
+		t.Fatalf("sha256=%q", info.SHA256)
+	}
+	if info.AssetName != assetName {
+		t.Fatalf("asset=%q want %q", info.AssetName, assetName)
+	}
+}
+
+func TestCheckLatestDevSuppressesNewer(t *testing.T) {
+	assetName := AssetName("2.0.0")
+	releases := []github.Release{{
+		TagName: "2.0.0",
+		Assets: []github.ReleaseAsset{{
+			Name:               assetName,
+			BrowserDownloadURL: "https://example.test/x.zip",
+			Digest:             "sha256:deadbeef",
+		}},
+	}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+	overrideGitHubClient(t, server)
+
+	info, newer, err := CheckLatest(context.Background(), "dev", false)
+	if err != nil {
+		t.Fatalf("CheckLatest: %v", err)
+	}
+	if newer {
+		t.Fatal("dev should report newer=false")
+	}
+	if info == nil || info.Tag != "2.0.0" {
+		t.Fatalf("info=%+v", info)
+	}
+}
+
+func TestCheckLatestSkipsPrereleases(t *testing.T) {
+	releases := []github.Release{
+		{
+			TagName:    "1.5.0-pre",
+			Prerelease: true,
+			Assets: []github.ReleaseAsset{{
+				Name:   AssetName("1.5.0-pre"),
+				Digest: "sha256:aa",
+			}},
+		},
+		{
+			TagName: "1.0.0",
+			Assets: []github.ReleaseAsset{{
+				Name:               AssetName("1.0.0"),
+				BrowserDownloadURL: "https://example.test/1.0.0.zip",
+				Digest:             "sha256:bb",
+			}},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	defer server.Close()
+	overrideGitHubClient(t, server)
+
+	info, _, err := CheckLatest(context.Background(), "0.9.0", false)
+	if err != nil {
+		t.Fatalf("CheckLatest: %v", err)
+	}
+	if info.Tag != "1.0.0" {
+		t.Fatalf("tag=%q want 1.0.0 (prerelease should be skipped)", info.Tag)
+	}
+}
+
+func TestAssetNameMatchesPlatform(t *testing.T) {
+	got := AssetName("9.9.9")
+	want := "gtnh-daily-updater-9.9.9-" + runtime.GOOS + "-" + runtime.GOARCH + ".zip"
+	if got != want {
+		t.Fatalf("AssetName=%q want %q", got, want)
+	}
+}

--- a/internal/selfupdate/repo.go
+++ b/internal/selfupdate/repo.go
@@ -1,0 +1,25 @@
+// Package selfupdate implements the self-update workflow: checking GitHub for
+// a newer release of this tool, downloading the matching binary, verifying its
+// SHA256, and atomically replacing the running executable.
+package selfupdate
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Repo is the GitHub repository hosting releases of this tool.
+const Repo = "Caedis/gtnh-daily-updater"
+
+// BinaryName is the platform binary name inside the release zip.
+func BinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "gtnh-daily-updater.exe"
+	}
+	return "gtnh-daily-updater"
+}
+
+// AssetName returns the release zip asset name for the current platform.
+func AssetName(version string) string {
+	return fmt.Sprintf("gtnh-daily-updater-%s-%s-%s.zip", version, runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
Adds opt-in startup update check and `self-update` subcommand that downloads the latest GitHub release, verifies SHA256 against the asset digest, and swaps the running binary. Windows leaves `.old` behind for cleanup on next launch.

Global config at platform config dir controls auto_update_check and include_prereleases; written with defaults on first run.