### PR TITLE
feat(extra): override manifest, regex jar select, case-insensitive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Add extra mods from direct URL:
 gtnh-daily-updater extra add CustomMod --source https://example.com/CustomMod.jar
 ```
 
+Pick a specific jar from a GitHub release that ships multiple variants. Use `--match <regex>` to select the asset; the pattern must uniquely match one `.jar`, otherwise the candidate names are listed so you can refine. Anchor patterns (e.g. `unlimited\.jar$`) to avoid matching `-dev`, `-sources`, or `-preshadow` variants:
+
+```bash
+gtnh-daily-updater extra add journeymap \
+    --source github:TeamJM/journeymap-legacy \
+    --match 'unlimited\.jar$'
+```
+
+A same-name extra overrides the manifest entry — no need to `exclude` the manifest's version first. This is the supported way to swap, for example, the manifest's `journeymap-fairplay` for the unlimited build from the same release.
+
 ## Profiles
 
 Profiles are stored as TOML files under the OS-native user config directory:

--- a/cmd/extra.go
+++ b/cmd/extra.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
@@ -18,6 +19,7 @@ var (
 	extraSource  string
 	extraVersion string
 	extraSide    string
+	extraMatch   string
 )
 
 var extraCmd = &cobra.Command{
@@ -34,7 +36,17 @@ var extraAddCmd = &cobra.Command{
   - --source github:Owner/Repo: downloads from GitHub releases
   - --source curseforge:12345: downloads latest release from CurseForge project
   - --source curseforge:12345/67890: downloads a specific CurseForge file
-  - --source https://example.com/mod.jar: downloads from direct URL`,
+  - --source https://example.com/mod.jar: downloads from direct URL
+
+When --source is github:Owner/Repo and the release contains multiple jars,
+use --match <regex> to select the desired asset. The pattern must uniquely
+match one .jar; on failure, the candidate jar names are listed so you can
+refine. Anchor patterns (e.g. 'unlimited\.jar$') to avoid matching
+'-dev', '-sources', or '-preshadow' variants.
+
+Example: extra add journeymap --source github:TeamJM/journeymap-legacy --match 'unlimited\.jar$'
+
+A same-name extra overrides the manifest entry — no need to exclude first.`,
 	Args: usageArgs(cobra.ExactArgs(1)),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
@@ -47,12 +59,22 @@ var extraAddCmd = &cobra.Command{
 		spec := config.ExtraModSpec{
 			Version: extraVersion,
 			Source:  extraSource,
+			Match:   extraMatch,
 		}
 		normalizedSide, err := normalizeExtraSide(extraSide)
 		if err != nil {
 			return err
 		}
 		spec.Side = normalizedSide
+
+		if strings.TrimSpace(spec.Match) != "" {
+			if !strings.HasPrefix(spec.Source, "github:") {
+				return wrapUsageError(fmt.Errorf("--match is only valid with --source github:Owner/Repo"))
+			}
+			if _, err := regexp.Compile(spec.Match); err != nil {
+				return wrapUsageError(fmt.Errorf("invalid --match regex %q: %w", spec.Match, err))
+			}
+		}
 
 		// Validate source
 		ctx := context.Background()
@@ -184,6 +206,9 @@ var extraListCmd = &cobra.Command{
 				version = "latest"
 			}
 			logging.Infof("  - %s (source: %s, version: %s, side: %s)\n", name, source, version, spec.Side)
+			if spec.Match != "" {
+				logging.Infof("      match: %s\n", spec.Match)
+			}
 		}
 		return nil
 	},
@@ -193,6 +218,7 @@ func init() {
 	extraAddCmd.Flags().StringVar(&extraSource, "source", "", "Mod source: github:Owner/Repo or direct URL (default: assets DB)")
 	extraAddCmd.Flags().StringVar(&extraVersion, "version", "", "Pin to specific version (default: latest)")
 	extraAddCmd.Flags().StringVar(&extraSide, "side", "", "Mod side: CLIENT, SERVER, or BOTH (default: BOTH)")
+	extraAddCmd.Flags().StringVar(&extraMatch, "match", "", "Regex to select a specific .jar from a multi-asset GitHub release (requires --source github:...)")
 	extraCmd.AddCommand(extraAddCmd)
 	extraCmd.AddCommand(extraRemoveCmd)
 	extraCmd.AddCommand(extraListCmd)

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -24,6 +24,7 @@ type ExtraModSpec struct {
 	Version string `json:"version,omitempty"`
 	Source  string `json:"source,omitempty"`
 	Side    string `json:"side,omitempty"`
+	Match   string `json:"match,omitempty"`
 }
 
 type InstalledMod struct {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -39,6 +39,11 @@ type ComputeOptions struct {
 }
 
 // Compute compares the current local state against a new manifest and returns the list of changes.
+//
+// Names are matched exactly. Callers that need case-insensitive matching
+// against the manifest should canonicalize state.ExcludeMods, state.ExtraMods,
+// and state.Mods to the manifest's casing before calling Compute (see
+// updater.CanonicalizeStateNames).
 func Compute(state *config.LocalState, newManifest *manifest.DailyManifest, opts *ComputeOptions) []ModChange {
 	newMods := newManifest.AllMods()
 	sideMode := state.Side
@@ -59,6 +64,16 @@ func Compute(state *config.LocalState, newManifest *manifest.DailyManifest, opts
 		s := side.Parse(info.Side)
 		if !s.IncludedIn(sideMode) {
 			continue
+		}
+
+		// Same-name extra overrides the manifest entry; the extras loop below
+		// emits Added/Updated/Unchanged. Skip here to avoid duplicate changes.
+		// This takes precedence over excludes — an extra with the same name is
+		// the user's explicit intent for this slot.
+		if opts != nil {
+			if _, isExtra := opts.ExtraMods[name]; isExtra {
+				continue
+			}
 		}
 
 		// Skip excluded mods — if currently installed, mark as Removed
@@ -125,10 +140,6 @@ func Compute(state *config.LocalState, newManifest *manifest.DailyManifest, opts
 	if opts != nil {
 		for _, name := range slices.Sorted(maps.Keys(opts.ExtraMods)) {
 			extra := opts.ExtraMods[name]
-			// Skip if already in manifest (manifest takes precedence unless excluded)
-			if _, inManifest := newMods[name]; inManifest && !excludeSet[name] {
-				continue
-			}
 
 			s := side.Parse(extra.Side)
 			if !s.IncludedIn(sideMode) {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -54,8 +54,8 @@ func TestCompute_WithExcludesAndExtras(t *testing.T) {
 	assertChange(t, got, "extra-kept", Unchanged, "9.0.0", "9.0.0")
 	assertChange(t, got, "extra-new", Added, "", "5.0.0")
 
-	// Manifest takes precedence over same-named extra unless excluded.
-	assertChange(t, got, "manifest-and-extra", Updated, "0.9.0", "1.0.0")
+	// Same-name extra overrides the manifest entry.
+	assertChange(t, got, "manifest-and-extra", Updated, "0.9.0", "2.0.0")
 
 	if _, ok := got["server-only"]; ok {
 		t.Fatalf("server-only mod should not be included in client mode")
@@ -86,6 +86,59 @@ func TestCompute_NilOptionsAndSideFiltering(t *testing.T) {
 		t.Fatalf("expected only one change, got %d", len(changes))
 	}
 	if changes[0].Name != "common" || changes[0].Type != Unchanged {
+		t.Fatalf("unexpected change: %+v", changes[0])
+	}
+}
+
+func TestCompute_SameNameExtraOverridesManifest_Uninstalled(t *testing.T) {
+	state := &config.LocalState{
+		Side: "client",
+		Mods: map[string]config.InstalledMod{},
+	}
+	m := &manifest.DailyManifest{
+		GithubMods: map[string]manifest.ModInfo{
+			"journeymap": {Version: "5.2.15-fairplay", Side: "CLIENT"},
+		},
+	}
+	opts := &ComputeOptions{
+		ExtraMods: map[string]ResolvedExtraMod{
+			"journeymap": {Version: "5.2.15", Side: "CLIENT"},
+		},
+	}
+
+	changes := Compute(state, m, opts)
+	if len(changes) != 1 {
+		t.Fatalf("expected single change, got %d: %+v", len(changes), changes)
+	}
+	if changes[0].Name != "journeymap" || changes[0].Type != Added || changes[0].NewVersion != "5.2.15" {
+		t.Fatalf("unexpected change: %+v", changes[0])
+	}
+}
+
+func TestCompute_ExcludeAndSameNameExtra_NoDuplicateChanges(t *testing.T) {
+	state := &config.LocalState{
+		Side: "client",
+		Mods: map[string]config.InstalledMod{
+			"journeymap": {Version: "old", Side: "CLIENT"},
+		},
+	}
+	m := &manifest.DailyManifest{
+		GithubMods: map[string]manifest.ModInfo{
+			"journeymap": {Version: "5.2.15-fairplay", Side: "CLIENT"},
+		},
+	}
+	opts := &ComputeOptions{
+		ExcludeMods: []string{"journeymap"},
+		ExtraMods: map[string]ResolvedExtraMod{
+			"journeymap": {Version: "5.2.15", Side: "CLIENT"},
+		},
+	}
+
+	changes := Compute(state, m, opts)
+	if len(changes) != 1 {
+		t.Fatalf("expected single change, got %d: %+v", len(changes), changes)
+	}
+	if changes[0].Name != "journeymap" || changes[0].Type != Updated || changes[0].NewVersion != "5.2.15" {
 		t.Fatalf("unexpected change: %+v", changes[0])
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/caedis/gtnh-daily-updater/internal/semver"
@@ -74,6 +75,39 @@ func PickPrimaryJar(releaseAssets []ReleaseAsset, version string) *ReleaseAsset 
 		return jars[0]
 	}
 	return nil
+}
+
+// PickJarMatching returns the single .jar asset whose name matches pattern.
+// Returns nil on zero or multiple matches; callers should error with the
+// candidate jar names so users can refine the pattern.
+func PickJarMatching(releaseAssets []ReleaseAsset, pattern *regexp.Regexp) *ReleaseAsset {
+	var matched *ReleaseAsset
+	count := 0
+	for i, asset := range releaseAssets {
+		if !strings.EqualFold(filepath.Ext(asset.Name), ".jar") {
+			continue
+		}
+		if pattern.MatchString(asset.Name) {
+			matched = &releaseAssets[i]
+			count++
+		}
+	}
+	if count == 1 {
+		return matched
+	}
+	return nil
+}
+
+// JarAssetNames returns the names of all .jar assets, for use in error
+// messages when PickJarMatching fails.
+func JarAssetNames(releaseAssets []ReleaseAsset) []string {
+	var names []string
+	for _, asset := range releaseAssets {
+		if strings.EqualFold(filepath.Ext(asset.Name), ".jar") {
+			names = append(names, asset.Name)
+		}
+	}
+	return names
 }
 
 // FetchLatestRelease fetches recent releases from a GitHub repo and returns

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"testing"
 )
 
@@ -48,6 +49,50 @@ func TestPickPrimaryJar(t *testing.T) {
 		}
 		if got := PickPrimaryJar(assets, "1.0.0"); got != nil {
 			t.Fatalf("PickPrimaryJar should be nil for ambiguous jars, got %v", got)
+		}
+	})
+}
+
+func TestPickJarMatching(t *testing.T) {
+	journeymapAssets := []ReleaseAsset{
+		{Name: "journeymap-1.7.10-5.2.15-dev.jar"},
+		{Name: "journeymap-1.7.10-5.2.15-fairplay.jar"},
+		{Name: "journeymap-1.7.10-5.2.15-unlimited-dev-preshadow.jar"},
+		{Name: "journeymap-1.7.10-5.2.15-unlimited-sources.jar"},
+		{Name: "journeymap-1.7.10-5.2.15-unlimited.jar"},
+	}
+
+	t.Run("anchored pattern uniquely matches", func(t *testing.T) {
+		re := regexp.MustCompile(`unlimited\.jar$`)
+		got := PickJarMatching(journeymapAssets, re)
+		if got == nil || got.Name != "journeymap-1.7.10-5.2.15-unlimited.jar" {
+			t.Fatalf("PickJarMatching=%v, want unlimited.jar", got)
+		}
+	})
+
+	t.Run("ambiguous pattern returns nil", func(t *testing.T) {
+		re := regexp.MustCompile(`unlimited`)
+		if got := PickJarMatching(journeymapAssets, re); got != nil {
+			t.Fatalf("PickJarMatching should be nil for ambiguous pattern, got %v", got)
+		}
+	})
+
+	t.Run("no match returns nil", func(t *testing.T) {
+		re := regexp.MustCompile(`nonexistent`)
+		if got := PickJarMatching(journeymapAssets, re); got != nil {
+			t.Fatalf("PickJarMatching should be nil for no match, got %v", got)
+		}
+	})
+
+	t.Run("non-jar assets ignored", func(t *testing.T) {
+		assets := []ReleaseAsset{
+			{Name: "thing.zip"},
+			{Name: "thing.jar"},
+		}
+		re := regexp.MustCompile(`thing`)
+		got := PickJarMatching(assets, re)
+		if got == nil || got.Name != "thing.jar" {
+			t.Fatalf("PickJarMatching=%v, want thing.jar", got)
 		}
 	})
 }

--- a/internal/updater/canonicalize.go
+++ b/internal/updater/canonicalize.go
@@ -1,0 +1,69 @@
+package updater
+
+import (
+	"strings"
+
+	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/manifest"
+)
+
+// canonicalizeStateNames rewrites case-sensitive name fields in state so they
+// match the manifest's casing. This lets users type `exclude add journeymap`
+// or `extra add JOURNEYMAP` and have the entry match a manifest mod named
+// "JourneyMap". Names absent from the manifest are left unchanged.
+//
+// Returns true if any name was rewritten so the caller can persist the
+// canonicalized state.
+func canonicalizeStateNames(state *config.LocalState, m *manifest.DailyManifest) bool {
+	if state == nil || m == nil {
+		return false
+	}
+
+	manifestCanon := make(map[string]string, len(m.GithubMods)+len(m.ExternalMods))
+	for k := range m.GithubMods {
+		manifestCanon[strings.ToLower(k)] = k
+	}
+	for k := range m.ExternalMods {
+		manifestCanon[strings.ToLower(k)] = k
+	}
+
+	changed := false
+
+	// state.Mods keys
+	if len(state.Mods) > 0 {
+		newMods := make(map[string]config.InstalledMod, len(state.Mods))
+		for k, v := range state.Mods {
+			canonical := k
+			if c, ok := manifestCanon[strings.ToLower(k)]; ok && c != k {
+				canonical = c
+				changed = true
+			}
+			newMods[canonical] = v
+		}
+		state.Mods = newMods
+	}
+
+	// state.ExcludeMods entries
+	for i, name := range state.ExcludeMods {
+		if c, ok := manifestCanon[strings.ToLower(name)]; ok && c != name {
+			state.ExcludeMods[i] = c
+			changed = true
+		}
+	}
+
+	// state.ExtraMods keys
+	if len(state.ExtraMods) > 0 {
+		newExtras := make(map[string]config.ExtraModSpec, len(state.ExtraMods))
+		for k, v := range state.ExtraMods {
+			canonical := k
+			if c, ok := manifestCanon[strings.ToLower(k)]; ok && c != k {
+				canonical = c
+				changed = true
+			}
+			newExtras[canonical] = v
+		}
+		state.ExtraMods = newExtras
+	}
+
+	return changed
+}

--- a/internal/updater/canonicalize_test.go
+++ b/internal/updater/canonicalize_test.go
@@ -1,0 +1,59 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/manifest"
+)
+
+func TestCanonicalizeStateNames(t *testing.T) {
+	state := &config.LocalState{
+		Mods: map[string]config.InstalledMod{
+			"journeymap": {Version: "old", Side: "CLIENT"},
+			"OtherMod":   {Version: "1.0", Side: "BOTH"},
+		},
+		ExcludeMods: []string{"JOURNEYMAP", "unknownmod"},
+		ExtraMods: map[string]config.ExtraModSpec{
+			"JourneyMap": {Source: "github:TeamJM/journeymap-legacy"},
+			"customMod":  {Source: "https://example.com/x.jar"},
+		},
+	}
+	m := &manifest.DailyManifest{
+		GithubMods: map[string]manifest.ModInfo{
+			"JourneyMap": {Version: "5.2.15", Side: "CLIENT"},
+		},
+		ExternalMods: map[string]manifest.ModInfo{
+			"OtherMod": {Version: "1.0", Side: "BOTH"},
+		},
+	}
+
+	changed := canonicalizeStateNames(state, m)
+	if !changed {
+		t.Fatal("expected canonicalizeStateNames to report changes")
+	}
+
+	if _, ok := state.Mods["JourneyMap"]; !ok {
+		t.Errorf("state.Mods key not canonicalized: %v", state.Mods)
+	}
+	if _, ok := state.Mods["journeymap"]; ok {
+		t.Errorf("old lowercase key still present in state.Mods")
+	}
+	if _, ok := state.Mods["OtherMod"]; !ok {
+		t.Errorf("unchanged matching key was lost: %v", state.Mods)
+	}
+
+	if state.ExcludeMods[0] != "JourneyMap" {
+		t.Errorf("ExcludeMods[0]=%q, want JourneyMap", state.ExcludeMods[0])
+	}
+	if state.ExcludeMods[1] != "unknownmod" {
+		t.Errorf("ExcludeMods[1] should be unchanged when not in manifest, got %q", state.ExcludeMods[1])
+	}
+
+	if _, ok := state.ExtraMods["JourneyMap"]; !ok {
+		t.Errorf("ExtraMods key not canonicalized: %v", state.ExtraMods)
+	}
+	if _, ok := state.ExtraMods["customMod"]; !ok {
+		t.Errorf("ExtraMods key absent from manifest should be unchanged")
+	}
+}

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -402,9 +403,22 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 
 		version = release.TagName
 
-		asset := github.PickPrimaryJar(release.Assets, version)
-		if asset == nil {
-			return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("no primary .jar asset found in release %s of %s", version, repo)
+		var asset *github.ReleaseAsset
+		if strings.TrimSpace(spec.Match) != "" {
+			re, err := regexp.Compile(spec.Match)
+			if err != nil {
+				return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("invalid match pattern %q for extra %s: %w", spec.Match, name, err)
+			}
+			asset = github.PickJarMatching(release.Assets, re)
+			if asset == nil {
+				candidates := github.JarAssetNames(release.Assets)
+				return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("match pattern %q for extra %s did not uniquely identify a jar in release %s of %s; candidates: %s", spec.Match, name, version, repo, strings.Join(candidates, ", "))
+			}
+		} else {
+			asset = github.PickPrimaryJar(release.Assets, version)
+			if asset == nil {
+				return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("no primary .jar asset found in release %s of %s", version, repo)
+			}
 		}
 		downloadURL := asset.BrowserDownloadURL
 		isGitHubAPI := false

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -27,6 +27,10 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	}
 	opts.AllowPreRelease = (mode == manifest.ModeExperimental)
 
+	// Match user-supplied exclude/extra names to manifest casing so
+	// `exclude add journeymap` matches manifest's "JourneyMap" entry.
+	canonicalizeStateNames(state, m)
+
 	gameDir := config.GameDir(opts.InstanceDir)
 	modsDir := filepath.Join(gameDir, "mods")
 


### PR DESCRIPTION
- Same-name extra now supersedes the manifest entry (and exclude), collapsing the exclude+extra workaround that left journeymap in a non-deterministic state across runs.
- --match <regex> picks one .jar from a multi-asset GitHub release; enables targeting journeymap-legacy's unlimited variant alongside fairplay/dev/sources jars in the same release.
- Mod names in state (Mods, ExcludeMods, ExtraMods) are canonicalized to manifest casing on each run so `exclude add journeymap` matches manifest "JourneyMap".

Closes #26