### PR TITLE
feat(extra): add Modrinth source for extra mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ Add extra mods from GitHub releases:
 gtnh-daily-updater extra add SomeMod --source github:Owner/Repo
 ```
 
-Note: Adding CurseForge extra mods requires a CurseForge API key  
-
-Add extra mods from CurseForge (latest release file):
+Add extra mods from CurseForge (latest release file, requires CurseForge API key):
 
 ```bash
 gtnh-daily-updater extra add SomeMod --source curseforge:12345
@@ -171,6 +169,18 @@ Add extra mods from CurseForge (pinned file):
 
 ```bash
 gtnh-daily-updater extra add SomeMod --source curseforge:12345/67890
+```
+
+Add extra mods from Modrinth (latest release, no API key needed, rate limit 300/min/ip):
+
+```bash
+gtnh-daily-updater extra add SomeMod --source modrinth:slug-or-id
+```
+
+Add extra mods from Modrinth (pinned version):
+
+```bash
+gtnh-daily-updater extra add SomeMod --source modrinth:slug-or-id/versionID
 ```
 
 Add extra mods from direct URL:

--- a/cmd/extra.go
+++ b/cmd/extra.go
@@ -11,6 +11,7 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/curseforge"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
+	"github.com/caedis/gtnh-daily-updater/internal/modrinth"
 	"github.com/caedis/gtnh-daily-updater/internal/side"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +37,8 @@ var extraAddCmd = &cobra.Command{
   - --source github:Owner/Repo: downloads from GitHub releases
   - --source curseforge:12345: downloads latest release from CurseForge project
   - --source curseforge:12345/67890: downloads a specific CurseForge file
+  - --source modrinth:slug-or-id: downloads latest release from Modrinth
+  - --source modrinth:slug-or-id/versionID: downloads a specific Modrinth version
   - --source https://example.com/mod.jar: downloads from direct URL
 
 When --source is github:Owner/Repo and the release contains multiple jars,
@@ -126,11 +129,28 @@ A same-name extra overrides the manifest entry — no need to exclude first.`,
 			} else {
 				logging.Infof("  CurseForge source: project %d (latest release)\n", projectID)
 			}
+		} else if rest, ok := strings.CutPrefix(spec.Source, "modrinth:"); ok {
+			project, versionID, err := modrinth.ParseSource(rest)
+			if err != nil {
+				return wrapUsageError(fmt.Errorf("invalid --source %q: %w", spec.Source, err))
+			}
+			exists, err := modrinth.ProjectExists(ctx, project)
+			if err != nil {
+				return fmt.Errorf("checking Modrinth project: %w", err)
+			}
+			if !exists {
+				return fmt.Errorf("Modrinth project %q not found", project)
+			}
+			if versionID != "" {
+				logging.Infof("  Modrinth source: project %s, version %s (pinned)\n", project, versionID)
+			} else {
+				logging.Infof("  Modrinth source: project %s (latest release)\n", project)
+			}
 		} else if strings.HasPrefix(spec.Source, "http://") || strings.HasPrefix(spec.Source, "https://") {
 			// Direct URL — just note it
 			logging.Infof("  Direct URL source: %s\n", spec.Source)
 		} else {
-			return wrapUsageError(fmt.Errorf("invalid source %q: must be empty (assets DB), github:Owner/Repo, curseforge:12345, or a URL", spec.Source))
+			return wrapUsageError(fmt.Errorf("invalid source %q: must be empty (assets DB), github:Owner/Repo, curseforge:12345, modrinth:slug, or a URL", spec.Source))
 		}
 
 		if state.ExtraMods == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/caedis/gtnh-daily-updater/internal/globalconfig"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
+	"github.com/caedis/gtnh-daily-updater/internal/modrinth"
 	"github.com/caedis/gtnh-daily-updater/internal/paths"
 	"github.com/caedis/gtnh-daily-updater/internal/profile"
 	"github.com/caedis/gtnh-daily-updater/internal/selfupdate"
@@ -141,6 +142,8 @@ func Execute() {
 }
 
 func init() {
+	modrinth.SetVersion(version)
+
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return wrapUsageError(err)
 	})

--- a/internal/modrinth/modrinth.go
+++ b/internal/modrinth/modrinth.go
@@ -1,0 +1,200 @@
+package modrinth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// GTNHGameVersion is the Minecraft version GTNH targets.
+const GTNHGameVersion = "1.7.10"
+
+// GTNHLoader is the mod loader used by GTNH.
+const GTNHLoader = "forge"
+
+// UserAgent identifies this tool to the Modrinth API (recommended by Modrinth).
+// cmd/root.go overrides it with the build version on init.
+var UserAgent = "github.com/caedis/gtnh-daily-updater/dev"
+
+// baseURL and httpClient are vars so tests can override them.
+var (
+	baseURL    = "https://api.modrinth.com"
+	httpClient = http.DefaultClient
+)
+
+// SetVersion updates the User-Agent string with the current build version.
+func SetVersion(v string) {
+	if v == "" {
+		return
+	}
+	UserAgent = "github.com/caedis/gtnh-daily-updater/" + v
+}
+
+// File represents a file attached to a Modrinth version.
+type File struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
+	Primary  bool   `json:"primary"`
+}
+
+// Version represents a Modrinth project version.
+type Version struct {
+	ID            string   `json:"id"`
+	ProjectID     string   `json:"project_id"`
+	VersionNumber string   `json:"version_number"`
+	VersionType   string   `json:"version_type"` // release | beta | alpha
+	Loaders       []string `json:"loaders"`
+	GameVersions  []string `json:"game_versions"`
+	Files         []File   `json:"files"`
+}
+
+// ParseSource parses the part of a modrinth source after the "modrinth:" prefix.
+// Accepted formats:
+//   - "slug-or-id"                 — use latest matching version
+//   - "slug-or-id/versionID"       — use that specific version
+func ParseSource(s string) (project, versionID string, err error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", "", fmt.Errorf("empty Modrinth source")
+	}
+	if proj, ver, hasVer := strings.Cut(s, "/"); hasVer {
+		if proj == "" || ver == "" {
+			return "", "", fmt.Errorf("invalid Modrinth source %q: expected slug[/versionID]", s)
+		}
+		return proj, ver, nil
+	}
+	return s, "", nil
+}
+
+// FetchLatestVersion returns the newest release version of a Modrinth project
+// that matches the given game version and loader.
+func FetchLatestVersion(ctx context.Context, project, gameVersion, loader string) (Version, error) {
+	q := url.Values{}
+	if gameVersion != "" {
+		q.Set("game_versions", fmt.Sprintf("[%q]", gameVersion))
+	}
+	if loader != "" {
+		q.Set("loaders", fmt.Sprintf("[%q]", loader))
+	}
+	endpoint := fmt.Sprintf("%s/v2/project/%s/version", baseURL, url.PathEscape(project))
+	if encoded := q.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	req, err := newRequest(ctx, endpoint)
+	if err != nil {
+		return Version{}, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Version{}, fmt.Errorf("fetching Modrinth versions for %s: %w", project, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatus(resp.StatusCode, fmt.Sprintf("project %s versions", project)); err != nil {
+		return Version{}, err
+	}
+
+	var versions []Version
+	if err := json.NewDecoder(resp.Body).Decode(&versions); err != nil {
+		return Version{}, fmt.Errorf("parsing Modrinth versions response: %w", err)
+	}
+
+	// Prefer release versions; fall back to first match if none.
+	for _, v := range versions {
+		if v.VersionType == "release" {
+			return v, nil
+		}
+	}
+	if len(versions) > 0 {
+		return versions[0], nil
+	}
+	return Version{}, fmt.Errorf("no versions found for Modrinth project %s (gameVersion=%q loader=%q)", project, gameVersion, loader)
+}
+
+// FetchVersion returns a specific version by ID.
+func FetchVersion(ctx context.Context, versionID string) (Version, error) {
+	endpoint := fmt.Sprintf("%s/v2/version/%s", baseURL, url.PathEscape(versionID))
+
+	req, err := newRequest(ctx, endpoint)
+	if err != nil {
+		return Version{}, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Version{}, fmt.Errorf("fetching Modrinth version %s: %w", versionID, err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkStatus(resp.StatusCode, fmt.Sprintf("version %s", versionID)); err != nil {
+		return Version{}, err
+	}
+
+	var v Version
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return Version{}, fmt.Errorf("parsing Modrinth version response: %w", err)
+	}
+	return v, nil
+}
+
+// PrimaryFile returns the primary jar file from a version, or the first file
+// if none is flagged primary.
+func PrimaryFile(v Version) (File, error) {
+	if len(v.Files) == 0 {
+		return File{}, fmt.Errorf("Modrinth version %s has no files", v.ID)
+	}
+	for _, f := range v.Files {
+		if f.Primary {
+			return f, nil
+		}
+	}
+	return v.Files[0], nil
+}
+
+// ProjectExists checks whether a project slug/ID resolves on Modrinth.
+func ProjectExists(ctx context.Context, project string) (bool, error) {
+	endpoint := fmt.Sprintf("%s/v2/project/%s", baseURL, url.PathEscape(project))
+	req, err := newRequest(ctx, endpoint)
+	if err != nil {
+		return false, err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("checking Modrinth project %s: %w", project, err)
+	}
+	resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("Modrinth API returned HTTP %d for project %s", resp.StatusCode, project)
+	}
+}
+
+func newRequest(ctx context.Context, endpoint string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func checkStatus(code int, target string) error {
+	switch code {
+	case http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("Modrinth resource not found: %s", target)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("Modrinth rate limit hit (HTTP 429) for %s", target)
+	default:
+		return fmt.Errorf("Modrinth API returned HTTP %d for %s", code, target)
+	}
+}

--- a/internal/modrinth/modrinth_test.go
+++ b/internal/modrinth/modrinth_test.go
@@ -1,0 +1,229 @@
+package modrinth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseSource(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantProject string
+		wantVersion string
+		wantErr     bool
+	}{
+		{name: "slug only", input: "journeymap", wantProject: "journeymap"},
+		{name: "id only", input: "AANobbMI", wantProject: "AANobbMI"},
+		{name: "slug and version", input: "journeymap/abc123", wantProject: "journeymap", wantVersion: "abc123"},
+		{name: "empty", input: "", wantErr: true},
+		{name: "trailing slash", input: "journeymap/", wantErr: true},
+		{name: "leading slash", input: "/abc", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proj, ver, err := ParseSource(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSource(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSource(%q) unexpected error: %v", tt.input, err)
+			}
+			if proj != tt.wantProject || ver != tt.wantVersion {
+				t.Fatalf("ParseSource(%q) = (%q, %q), want (%q, %q)", tt.input, proj, ver, tt.wantProject, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestFetchLatestVersionPrefersRelease(t *testing.T) {
+	versions := []Version{
+		{ID: "v1", VersionType: "beta", Files: []File{{URL: "https://example.com/b.jar", Filename: "b.jar", Primary: true}}},
+		{ID: "v2", VersionType: "release", Files: []File{{URL: "https://example.com/r.jar", Filename: "r.jar", Primary: true}}},
+		{ID: "v3", VersionType: "release", Files: []File{{URL: "https://example.com/r2.jar", Filename: "r2.jar", Primary: true}}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v2/project/") {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("User-Agent") == "" {
+			http.Error(w, "missing UA", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(versions); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	got, err := FetchLatestVersion(context.Background(), "journeymap", "1.7.10", "forge")
+	if err != nil {
+		t.Fatalf("FetchLatestVersion: %v", err)
+	}
+	if got.ID != "v2" {
+		t.Errorf("FetchLatestVersion picked %q, want v2 (first release)", got.ID)
+	}
+}
+
+func TestFetchLatestVersionFallsBackWhenNoRelease(t *testing.T) {
+	versions := []Version{
+		{ID: "v1", VersionType: "beta", Files: []File{{URL: "https://example.com/b.jar", Filename: "b.jar", Primary: true}}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(versions)
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	got, err := FetchLatestVersion(context.Background(), "journeymap", "1.7.10", "forge")
+	if err != nil {
+		t.Fatalf("FetchLatestVersion: %v", err)
+	}
+	if got.ID != "v1" {
+		t.Errorf("FetchLatestVersion got %q, want v1", got.ID)
+	}
+}
+
+func TestFetchLatestVersionErrorsOnEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Version{})
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	if _, err := FetchLatestVersion(context.Background(), "journeymap", "1.7.10", "forge"); err == nil {
+		t.Fatal("expected error for empty versions, got nil")
+	}
+}
+
+func TestFetchVersionReturnsPinned(t *testing.T) {
+	want := Version{
+		ID:            "pin123",
+		VersionNumber: "1.2.3",
+		VersionType:   "release",
+		Files:         []File{{URL: "https://example.com/p.jar", Filename: "p.jar", Primary: true}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v2/version/pin123") {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	got, err := FetchVersion(context.Background(), "pin123")
+	if err != nil {
+		t.Fatalf("FetchVersion: %v", err)
+	}
+	if got.ID != want.ID || got.VersionNumber != want.VersionNumber {
+		t.Errorf("FetchVersion got {ID:%q Ver:%q}, want {ID:%q Ver:%q}", got.ID, got.VersionNumber, want.ID, want.VersionNumber)
+	}
+}
+
+func TestPrimaryFile(t *testing.T) {
+	v := Version{ID: "x", Files: []File{
+		{URL: "a", Filename: "a.jar"},
+		{URL: "b", Filename: "b.jar", Primary: true},
+	}}
+	f, err := PrimaryFile(v)
+	if err != nil {
+		t.Fatalf("PrimaryFile: %v", err)
+	}
+	if f.Filename != "b.jar" {
+		t.Errorf("PrimaryFile picked %q, want b.jar", f.Filename)
+	}
+
+	// No primary flag — first file
+	v2 := Version{ID: "x", Files: []File{{URL: "a", Filename: "a.jar"}}}
+	f, err = PrimaryFile(v2)
+	if err != nil {
+		t.Fatalf("PrimaryFile: %v", err)
+	}
+	if f.Filename != "a.jar" {
+		t.Errorf("PrimaryFile got %q, want a.jar", f.Filename)
+	}
+
+	// Empty files
+	if _, err := PrimaryFile(Version{ID: "x"}); err == nil {
+		t.Error("PrimaryFile expected error for no files")
+	}
+}
+
+func TestProjectExists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/found") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	origBase := baseURL
+	origClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() {
+		baseURL = origBase
+		httpClient = origClient
+	}()
+
+	if ok, err := ProjectExists(context.Background(), "found"); err != nil || !ok {
+		t.Errorf("ProjectExists(found) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if ok, err := ProjectExists(context.Background(), "missing"); err != nil || ok {
+		t.Errorf("ProjectExists(missing) = (%v, %v), want (false, nil)", ok, err)
+	}
+}

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/github"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/maven"
+	"github.com/caedis/gtnh-daily-updater/internal/modrinth"
 	"github.com/caedis/gtnh-daily-updater/internal/semver"
 )
 
@@ -358,6 +359,34 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 		return diff.ResolvedExtraMod{Version: version, Side: modSide}, resolvedExtra{
 			URL:      downloadURL,
 			Filename: file.FileName,
+		}, nil
+
+	case strings.HasPrefix(spec.Source, "modrinth:"):
+		rest := strings.TrimPrefix(spec.Source, "modrinth:")
+		project, versionID, err := modrinth.ParseSource(rest)
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		var ver modrinth.Version
+		if versionID != "" {
+			ver, err = modrinth.FetchVersion(ctx, versionID)
+		} else {
+			ver, err = modrinth.FetchLatestVersion(ctx, project, modrinth.GTNHGameVersion, modrinth.GTNHLoader)
+		}
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		file, err := modrinth.PrimaryFile(ver)
+		if err != nil {
+			return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+		}
+
+		logging.Debugf("Verbose: extra mod %s Modrinth project=%s version=%s filename=%s\n", name, project, ver.ID, file.Filename)
+		return diff.ResolvedExtraMod{Version: ver.ID, Side: modSide}, resolvedExtra{
+			URL:      file.URL,
+			Filename: file.Filename,
 		}, nil
 
 	case strings.HasPrefix(spec.Source, "github:"):


### PR DESCRIPTION
No API key required.
Supports `modrinth:slug` for latest release and `modrinth:slug/versionID` for pinned versions.
Filters by GTNH game version (1.7.10) and forge loader.
User-Agent carries build version per Modrinth's API guidelines.

Closes #27 

Tested with Neat (by Vazkii)