### PR TITLE
feat: validate sha256/sha1/sha512 on mod downloads

### DIFF
--- a/internal/curseforge/curseforge.go
+++ b/internal/curseforge/curseforge.go
@@ -20,15 +20,32 @@ var (
 	httpClient = http.DefaultClient
 )
 
+// FileHash is a CurseForge file hash entry. Algo: 1=sha1, 2=md5.
+type FileHash struct {
+	Value string `json:"value"`
+	Algo  int    `json:"algo"`
+}
+
 // File represents a CurseForge file entry.
 type File struct {
-	ID           int      `json:"id"`
-	ModID        int      `json:"modId"`
-	DisplayName  string   `json:"displayName"`
-	FileName     string   `json:"fileName"`
-	DownloadURL  string   `json:"downloadUrl"` // may be empty for some files
-	ReleaseType  int      `json:"releaseType"` // 1=Release, 2=Beta, 3=Alpha
-	GameVersions []string `json:"gameVersions"`
+	ID           int        `json:"id"`
+	ModID        int        `json:"modId"`
+	DisplayName  string     `json:"displayName"`
+	FileName     string     `json:"fileName"`
+	DownloadURL  string     `json:"downloadUrl"` // may be empty for some files
+	ReleaseType  int        `json:"releaseType"` // 1=Release, 2=Beta, 3=Alpha
+	GameVersions []string   `json:"gameVersions"`
+	Hashes       []FileHash `json:"hashes"`
+}
+
+// SHA1 returns the sha1 hex digest for this file, or "" if not present.
+func (f File) SHA1() string {
+	for _, h := range f.Hashes {
+		if h.Algo == 1 {
+			return h.Value
+		}
+	}
+	return ""
 }
 
 type fileResponse struct {

--- a/internal/curseforge/curseforge_test.go
+++ b/internal/curseforge/curseforge_test.go
@@ -3,6 +3,7 @@ package curseforge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -216,5 +217,40 @@ func TestFileVersion(t *testing.T) {
 	f := File{ID: 4586932}
 	if got := FileVersion(f); got != "4586932" {
 		t.Errorf("FileVersion = %q, want %q", got, "4586932")
+	}
+}
+
+func TestFile_SHA1(t *testing.T) {
+	f := File{Hashes: []FileHash{
+		{Algo: 2, Value: "deadbeef"},
+		{Algo: 1, Value: "abc123"},
+	}}
+	if got := f.SHA1(); got != "abc123" {
+		t.Fatalf("SHA1 = %q, want abc123", got)
+	}
+	empty := File{}
+	if got := empty.SHA1(); got != "" {
+		t.Fatalf("SHA1 on empty = %q, want \"\"", got)
+	}
+}
+
+func TestFetchFile_ParsesHashes(t *testing.T) {
+	body := `{"data":{"id":42,"modId":1,"fileName":"x.jar","hashes":[{"value":"AABB","algo":1},{"value":"CCDD","algo":2}]}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+	oldBase := baseURL
+	oldClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() { baseURL = oldBase; httpClient = oldClient }()
+
+	f, err := FetchFile(context.Background(), 1, 42, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.SHA1() != "AABB" {
+		t.Fatalf("SHA1 = %q, want AABB", f.SHA1())
 	}
 }

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -177,6 +177,7 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 				if errors.Is(vErr, ErrHashMismatch) {
 					logging.Debugf("Verbose: cache invalid mod=%s file=%s err=%v\n", dl.ModName, dl.Filename, vErr)
 					os.Remove(cachePath)
+					os.Remove(cachePath + ".sha256")
 				} else {
 					return vErr
 				}
@@ -193,6 +194,7 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 					if errors.Is(vErr, ErrHashMismatch) {
 						logging.Debugf("Verbose: legacy cache invalid mod=%s file=%s err=%v\n", dl.ModName, dl.Filename, vErr)
 						os.Remove(oldCachePath)
+						os.Remove(oldCachePath + ".sha256")
 					} else {
 						return vErr
 					}
@@ -232,7 +234,7 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 			return fmt.Errorf("creating cache dir for %s: %w", dl.ModName, err)
 		}
 		cachePath := filepath.Join(modCacheDir, safeFilename)
-		if err := writeAndHash(resp.Body, cachePath, dl.HashAlgo, dl.ExpectedHash, dl.Filename); err != nil {
+		if err := writeCacheAndHash(resp.Body, cachePath, dl.HashAlgo, dl.ExpectedHash, dl.Filename); err != nil {
 			return err
 		}
 		evictOldCacheFiles(modCacheDir, 5)
@@ -344,10 +346,47 @@ func newHasher(algo string) (*hasher, error) {
 func (h *hasher) Write(p []byte) (int, error) { return h.h.Write(p) }
 func (h *hasher) Hex() string                 { return hex.EncodeToString(h.h.Sum(nil)) }
 
-// validateCachedFile streams the cached file through a hasher. Returns
-// ErrHashMismatch (wrapped) if mismatch, nil if match or algo is empty.
-func validateCachedFile(path, algo, expected string) error {
-	if algo == "" || expected == "" {
+// readCacheSidecar reads the sha256 sidecar file for jarPath (jarPath+".sha256").
+// Returns ("", os.ErrNotExist) if missing, or the trimmed lowercase hex on success.
+func readCacheSidecar(jarPath string) (string, error) {
+	data, err := os.ReadFile(jarPath + ".sha256")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(strings.TrimSpace(string(data))), nil
+}
+
+// fileSHA256 streams path through a sha256 hasher and returns the lowercase hex digest.
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// validateCachedFile checks a cached jar for integrity. It prefers the sha256
+// sidecar (jarPath+".sha256") if present; falls back to upstreamAlgo/upstreamExpected
+// if no sidecar; skips validation if neither is available.
+// Returns ErrHashMismatch (wrapped) on mismatch, nil on pass or skip.
+func validateCachedFile(path, upstreamAlgo, upstreamExpected string) error {
+	if sha, err := readCacheSidecar(path); err == nil && sha != "" {
+		got, err := fileSHA256(path)
+		if err != nil {
+			return err
+		}
+		if got != sha {
+			return fmt.Errorf("cache %s: %w (sidecar got=%s want=%s)", filepath.Base(path), ErrHashMismatch, got, sha)
+		}
+		return nil
+	}
+	// No sidecar - fall back to upstream hash if known.
+	if upstreamAlgo == "" || upstreamExpected == "" {
 		return nil
 	}
 	f, err := os.Open(path)
@@ -355,7 +394,7 @@ func validateCachedFile(path, algo, expected string) error {
 		return err
 	}
 	defer f.Close()
-	h, err := newHasher(algo)
+	h, err := newHasher(upstreamAlgo)
 	if err != nil {
 		return err
 	}
@@ -363,10 +402,83 @@ func validateCachedFile(path, algo, expected string) error {
 		return err
 	}
 	got := h.Hex()
-	want := strings.ToLower(expected)
+	want := strings.ToLower(upstreamExpected)
 	if got != want {
-		return fmt.Errorf("cache %s: %w (algo=%s got=%s want=%s)", filepath.Base(path), ErrHashMismatch, algo, got, want)
+		return fmt.Errorf("cache %s: %w (algo=%s got=%s want=%s)", filepath.Base(path), ErrHashMismatch, upstreamAlgo, got, want)
 	}
+	return nil
+}
+
+// writeCacheAndHash writes src to cachePath via a .tmp file, validating the
+// upstream hash (if algo+expected non-empty) and always computing a sha256
+// sidecar file (cachePath+".sha256") for future cache validation.
+// On upstream hash mismatch the tmp is removed and ErrHashMismatch is returned.
+// If writing the sidecar fails it is logged but does not fail the download.
+func writeCacheAndHash(src io.Reader, cachePath, upstreamAlgo, upstreamExpected, label string) error {
+	tmpPath := cachePath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", label, err)
+	}
+
+	sha256h := sha256.New()
+	var writers []io.Writer
+	writers = append(writers, f, sha256h)
+
+	var upstreamHasher *hasher
+	// If upstream algo is sha256 we reuse sha256h to avoid double-hashing.
+	if upstreamAlgo != "" && upstreamExpected != "" {
+		if upstreamAlgo == "sha256" {
+			// sha256h already covers this; set upstreamHasher to nil sentinel handled below.
+		} else {
+			upstreamHasher, err = newHasher(upstreamAlgo)
+			if err != nil {
+				f.Close()
+				os.Remove(tmpPath)
+				return err
+			}
+			writers = append(writers, upstreamHasher)
+		}
+	}
+
+	w := io.MultiWriter(writers...)
+	_, copyErr := io.Copy(w, src)
+	closeErr := f.Close()
+	if copyErr != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing %s: %w", label, copyErr)
+	}
+	if closeErr != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing %s: %w", label, closeErr)
+	}
+
+	// Validate upstream hash if requested.
+	if upstreamAlgo != "" && upstreamExpected != "" {
+		want := strings.ToLower(upstreamExpected)
+		var got string
+		if upstreamAlgo == "sha256" {
+			got = hex.EncodeToString(sha256h.Sum(nil))
+		} else {
+			got = upstreamHasher.Hex()
+		}
+		if got != want {
+			os.Remove(tmpPath)
+			return fmt.Errorf("%s: %w (algo=%s got=%s want=%s)", label, ErrHashMismatch, upstreamAlgo, got, want)
+		}
+	}
+
+	if err := os.Rename(tmpPath, cachePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("finalizing %s: %w", label, err)
+	}
+
+	// Write sha256 sidecar atomically. Failure is non-fatal.
+	sha256hex := hex.EncodeToString(sha256h.Sum(nil))
+	if werr := os.WriteFile(cachePath+".sha256", []byte(sha256hex+"\n"), 0644); werr != nil {
+		logging.Debugf("Verbose: failed to write sidecar for %s: %v\n", label, werr)
+	}
+
 	return nil
 }
 
@@ -419,8 +531,10 @@ func writeAndHash(src io.Reader, dstPath, algo, expected, label string) error {
 	return nil
 }
 
-// evictOldCacheFiles removes the oldest files in dir, keeping only the newest
-// keep entries. Errors are logged but not returned since eviction is best-effort.
+// evictOldCacheFiles removes the oldest jar files in dir, keeping only the newest
+// keep entries. Sidecar (.sha256) files are excluded from counting and are removed
+// alongside their jar when the jar is evicted. Errors are logged but not returned
+// since eviction is best-effort.
 func evictOldCacheFiles(dir string, keep int) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -435,6 +549,10 @@ func evictOldCacheFiles(dir string, keep int) {
 	var files []fileEntry
 	for _, e := range entries {
 		if e.IsDir() {
+			continue
+		}
+		// Skip sidecar files; they are managed together with their jar.
+		if strings.HasSuffix(e.Name(), ".sha256") {
 			continue
 		}
 		info, err := e.Info()
@@ -460,5 +578,7 @@ func evictOldCacheFiles(dir string, keep int) {
 		} else {
 			logging.Debugf("Verbose: evicted old cached file %s\n", path)
 		}
+		// Remove the sidecar alongside the jar (ignore error; it may not exist).
+		os.Remove(path + ".sha256")
 	}
 }

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -166,15 +166,33 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 		modCacheDir := filepath.Join(cacheDir, safeModName)
 		cachePath := filepath.Join(modCacheDir, safeFilename)
 		if _, err := os.Stat(cachePath); err == nil {
-			logging.Debugf("Verbose: cache hit mod=%s file=%s\n", dl.ModName, dl.Filename)
-			return copyFile(cachePath, destPath)
+			if vErr := validateCachedFile(cachePath, dl.HashAlgo, dl.ExpectedHash); vErr != nil {
+				if errors.Is(vErr, ErrHashMismatch) {
+					logging.Debugf("Verbose: cache invalid mod=%s file=%s err=%v\n", dl.ModName, dl.Filename, vErr)
+					os.Remove(cachePath)
+				} else {
+					return vErr
+				}
+			} else {
+				logging.Debugf("Verbose: cache hit mod=%s file=%s\n", dl.ModName, dl.Filename)
+				return copyFile(cachePath, destPath)
+			}
 		}
 		// Fall back to old unsanitized cache path for backwards compatibility
 		oldCachePath := filepath.Join(cacheDir, dl.ModName, dl.Filename)
 		if oldCachePath != cachePath {
 			if _, err := os.Stat(oldCachePath); err == nil {
-				logging.Debugf("Verbose: cache hit (legacy path) mod=%s file=%s\n", dl.ModName, dl.Filename)
-				return copyFile(oldCachePath, destPath)
+				if vErr := validateCachedFile(oldCachePath, dl.HashAlgo, dl.ExpectedHash); vErr != nil {
+					if errors.Is(vErr, ErrHashMismatch) {
+						logging.Debugf("Verbose: legacy cache invalid mod=%s file=%s err=%v\n", dl.ModName, dl.Filename, vErr)
+						os.Remove(oldCachePath)
+					} else {
+						return vErr
+					}
+				} else {
+					logging.Debugf("Verbose: cache hit (legacy path) mod=%s file=%s\n", dl.ModName, dl.Filename)
+					return copyFile(oldCachePath, destPath)
+				}
 			}
 		}
 		logging.Debugf("Verbose: cache miss mod=%s file=%s\n", dl.ModName, dl.Filename)
@@ -318,6 +336,32 @@ func newHasher(algo string) (*hasher, error) {
 
 func (h *hasher) Write(p []byte) (int, error) { return h.h.Write(p) }
 func (h *hasher) Hex() string                 { return hex.EncodeToString(h.h.Sum(nil)) }
+
+// validateCachedFile streams the cached file through a hasher. Returns
+// ErrHashMismatch (wrapped) if mismatch, nil if match or algo is empty.
+func validateCachedFile(path, algo, expected string) error {
+	if algo == "" || expected == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h, err := newHasher(algo)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := h.Hex()
+	want := strings.ToLower(expected)
+	if got != want {
+		return fmt.Errorf("cache %s: %w (algo=%s got=%s want=%s)", filepath.Base(path), ErrHashMismatch, algo, got, want)
+	}
+	return nil
+}
 
 // writeAndHash copies src to dstPath via a .tmp file, optionally validating the
 // hash. On mismatch the .tmp is removed and an ErrHashMismatch-wrapped error

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -200,65 +201,23 @@ func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheD
 		return fmt.Errorf("downloading %s: HTTP %d", dl.Filename, resp.StatusCode)
 	}
 
-	// If caching, download to cache first, then copy to dest
 	if cacheDir != "" {
 		modCacheDir := filepath.Join(cacheDir, safeModName)
 		if err := os.MkdirAll(modCacheDir, 0755); err != nil {
 			return fmt.Errorf("creating cache dir for %s: %w", dl.ModName, err)
 		}
 		cachePath := filepath.Join(modCacheDir, safeFilename)
-		cacheTmp := cachePath + ".tmp"
-
-		f, err := os.Create(cacheTmp)
-		if err != nil {
-			return fmt.Errorf("creating cache file for %s: %w", dl.Filename, err)
+		if err := writeAndHash(resp.Body, cachePath, dl.HashAlgo, dl.ExpectedHash, dl.Filename); err != nil {
+			return err
 		}
-
-		_, err = io.Copy(f, resp.Body)
-		closeErr := f.Close()
-		if err != nil {
-			os.Remove(cacheTmp)
-			return fmt.Errorf("writing %s: %w", dl.Filename, err)
-		}
-		if closeErr != nil {
-			os.Remove(cacheTmp)
-			return fmt.Errorf("closing %s: %w", dl.Filename, closeErr)
-		}
-
-		if err := os.Rename(cacheTmp, cachePath); err != nil {
-			os.Remove(cacheTmp)
-			return fmt.Errorf("finalizing cache for %s: %w", dl.Filename, err)
-		}
-
 		evictOldCacheFiles(modCacheDir, 5)
 		return copyFile(cachePath, destPath)
 	}
 
-	// No cache — download directly to destDir
-	tmpPath := destPath + ".tmp"
-
-	f, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("creating %s: %w", dl.Filename, err)
-	}
-
-	_, err = io.Copy(f, resp.Body)
-	closeErr := f.Close()
-	if err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("writing %s: %w", dl.Filename, err)
-	}
-	if closeErr != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("closing %s: %w", dl.Filename, closeErr)
-	}
-
-	if err := os.Rename(tmpPath, destPath); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("finalizing %s: %w", dl.Filename, err)
+	if err := writeAndHash(resp.Body, destPath, dl.HashAlgo, dl.ExpectedHash, dl.Filename); err != nil {
+		return err
 	}
 	logging.Debugf("Verbose: download complete file=%s\n", dl.Filename)
-
 	return nil
 }
 
@@ -359,6 +318,55 @@ func newHasher(algo string) (*hasher, error) {
 
 func (h *hasher) Write(p []byte) (int, error) { return h.h.Write(p) }
 func (h *hasher) Hex() string                 { return hex.EncodeToString(h.h.Sum(nil)) }
+
+// writeAndHash copies src to dstPath via a .tmp file, optionally validating the
+// hash. On mismatch the .tmp is removed and an ErrHashMismatch-wrapped error
+// is returned.
+func writeAndHash(src io.Reader, dstPath, algo, expected, label string) error {
+	tmpPath := dstPath + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", label, err)
+	}
+
+	var h *hasher
+	var w io.Writer = f
+	if algo != "" && expected != "" {
+		h, err = newHasher(algo)
+		if err != nil {
+			f.Close()
+			os.Remove(tmpPath)
+			return err
+		}
+		w = io.MultiWriter(f, h)
+	}
+
+	_, copyErr := io.Copy(w, src)
+	closeErr := f.Close()
+	if copyErr != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing %s: %w", label, copyErr)
+	}
+	if closeErr != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing %s: %w", label, closeErr)
+	}
+
+	if h != nil {
+		got := h.Hex()
+		want := strings.ToLower(expected)
+		if got != want {
+			os.Remove(tmpPath)
+			return fmt.Errorf("%s: %w (algo=%s got=%s want=%s)", label, ErrHashMismatch, algo, got, want)
+		}
+	}
+
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("finalizing %s: %w", label, err)
+	}
+	return nil
+}
 
 // evictOldCacheFiles removes the oldest files in dir, keeping only the newest
 // keep entries. Errors are logged but not returned since eviction is best-effort.

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -112,6 +112,13 @@ func downloadFileWithRetry(ctx context.Context, dl Download, destDir, githubToke
 	fallback.URL = dl.MavenFallbackURL
 	fallback.IsGitHubAPI = false
 	fallback.MavenFallbackURL = ""
+	if dl.MavenFallbackHash != "" {
+		fallback.ExpectedHash = dl.MavenFallbackHash
+		fallback.HashAlgo = "sha256"
+	} else {
+		fallback.ExpectedHash = ""
+		fallback.HashAlgo = ""
+	}
 	logging.Debugf(
 		"Verbose: github download failed for %s (%v); trying maven fallback url=%s\n",
 		dl.Filename,

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,8 +2,13 @@ package downloader
 
 import (
 	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"os"
@@ -334,6 +339,26 @@ func downloadToFileOnce(ctx context.Context, url, destPath, githubToken string, 
 
 	return nil
 }
+
+type hasher struct {
+	h hash.Hash
+}
+
+func newHasher(algo string) (*hasher, error) {
+	switch algo {
+	case "sha256":
+		return &hasher{h: sha256.New()}, nil
+	case "sha1":
+		return &hasher{h: sha1.New()}, nil
+	case "sha512":
+		return &hasher{h: sha512.New()}, nil
+	default:
+		return nil, fmt.Errorf("unsupported hash algo %q", algo)
+	}
+}
+
+func (h *hasher) Write(p []byte) (int, error) { return h.h.Write(p) }
+func (h *hasher) Hex() string                 { return hex.EncodeToString(h.h.Sum(nil)) }
 
 // evictOldCacheFiles removes the oldest files in dir, keeping only the newest
 // keep entries. Errors are logged but not returned since eviction is best-effort.

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,10 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 )
 
+// ErrHashMismatch indicates a downloaded or cached file's hash did not match
+// the expected hash after all retries.
+var ErrHashMismatch = errors.New("hash mismatch")
+
 type Download struct {
 	URL      string
 	Filename string
@@ -25,6 +30,13 @@ type Download struct {
 	IsGitHubAPI bool
 	// MavenFallbackURL is used when a GitHub download fails after retries.
 	MavenFallbackURL string
+	// ExpectedHash is the lowercase hex digest the downloaded bytes must match.
+	// Empty disables validation.
+	ExpectedHash string
+	// HashAlgo selects the algorithm: "sha256", "sha1", "sha512". Empty disables.
+	HashAlgo string
+	// MavenFallbackHash is the expected sha256 for MavenFallbackURL. Empty disables on fallback.
+	MavenFallbackHash string
 }
 
 type Result struct {

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,0 +1,54 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestNewHasher_Algos(t *testing.T) {
+	cases := []struct {
+		algo string
+		want string // hex digest of "hello"
+	}{
+		{"sha256", "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
+		{"sha1", "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"},
+		{"sha512", "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043"},
+	}
+	for _, c := range cases {
+		h, err := newHasher(c.algo)
+		if err != nil {
+			t.Fatalf("%s: %v", c.algo, err)
+		}
+		h.Write([]byte("hello"))
+		if got := h.Hex(); got != c.want {
+			t.Fatalf("%s: got %s want %s", c.algo, got, c.want)
+		}
+	}
+	if _, err := newHasher(""); err == nil {
+		t.Fatal("empty algo: want error")
+	}
+	if _, err := newHasher("md5"); err == nil {
+		t.Fatal("md5: want error")
+	}
+}
+
+// Keep imports satisfied for later tasks that will add tests using these.
+var _ = bytes.NewBuffer
+var _ = context.Background
+var _ = errors.Is
+var _ = fmt.Sprint
+var _ = http.MethodGet
+var _ = httptest.NewServer
+var _ = os.Open
+var _ = filepath.Join
+var _ = strings.TrimSpace
+var _ atomic.Int32

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -159,5 +160,130 @@ func TestRun_CacheHit_ValidMatches(t *testing.T) {
 	)
 	if results[0].Err != nil {
 		t.Fatalf("err = %v", results[0].Err)
+	}
+}
+
+func TestRun_FreshDownloadWritesSidecar(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	dest := t.TempDir()
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}}, // no upstream hash
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatal(results[0].Err)
+	}
+	sidecar, err := os.ReadFile(filepath.Join(cache, "m", "x.jar.sha256"))
+	if err != nil {
+		t.Fatalf("sidecar missing: %v", err)
+	}
+	if strings.TrimSpace(string(sidecar)) != goodSHA256 {
+		t.Fatalf("sidecar = %q, want %s", sidecar, goodSHA256)
+	}
+}
+
+func TestRun_CacheCorrupt_NoUpstreamHash_DetectedViaSidecar(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	dest := t.TempDir()
+	modDir := filepath.Join(cache, "m")
+	os.MkdirAll(modDir, 0755)
+	// Seed corrupt jar with VALID sidecar (sidecar from previous good download)
+	os.WriteFile(filepath.Join(modDir, "x.jar"), []byte("corrupt"), 0644)
+	os.WriteFile(filepath.Join(modDir, "x.jar.sha256"), []byte(goodSHA256+"\n"), 0644)
+
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}}, // NO upstream hash
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatal(results[0].Err)
+	}
+	if hits.Load() == 0 {
+		t.Fatal("expected refetch on sidecar mismatch")
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, "x.jar"))
+	if string(got) != goodBytes {
+		t.Fatalf("dest = %q", got)
+	}
+}
+
+func TestRun_CacheValid_SidecarSkipsNetwork(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not contact server")
+	}))
+	defer srv.Close()
+	cache := t.TempDir()
+	dest := t.TempDir()
+	modDir := filepath.Join(cache, "m")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "x.jar"), []byte(goodBytes), 0644)
+	os.WriteFile(filepath.Join(modDir, "x.jar.sha256"), []byte(goodSHA256+"\n"), 0644)
+
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}},
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatal(results[0].Err)
+	}
+}
+
+func TestRun_CacheNoSidecarNoHash_SkipsValidation(t *testing.T) {
+	// Backwards compat: old cache entry without sidecar and no upstream hash -> trusted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not contact server")
+	}))
+	defer srv.Close()
+	cache := t.TempDir()
+	dest := t.TempDir()
+	modDir := filepath.Join(cache, "m")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "x.jar"), []byte("anything"), 0644)
+	// no sidecar
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}},
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatal(results[0].Err)
+	}
+}
+
+func TestRun_CacheMismatchInvalidatesSidecar(t *testing.T) {
+	// After mismatch + refetch, the BAD sidecar must be replaced.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+	cache := t.TempDir()
+	dest := t.TempDir()
+	modDir := filepath.Join(cache, "m")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "x.jar"), []byte("corrupt"), 0644)
+	os.WriteFile(filepath.Join(modDir, "x.jar.sha256"), []byte(goodSHA256+"\n"), 0644)
+
+	Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}},
+		dest, 1, "", cache, nil,
+	)
+	sidecar, _ := os.ReadFile(filepath.Join(modDir, "x.jar.sha256"))
+	if strings.TrimSpace(string(sidecar)) != goodSHA256 {
+		t.Fatalf("sidecar after refetch = %q, want %s", sidecar, goodSHA256)
+	}
+	jar, _ := os.ReadFile(filepath.Join(modDir, "x.jar"))
+	if string(jar) != goodBytes {
+		t.Fatalf("cache jar = %q", jar)
 	}
 }

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,7 +1,6 @@
 package downloader
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -41,14 +39,65 @@ func TestNewHasher_Algos(t *testing.T) {
 	}
 }
 
-// Keep imports satisfied for later tasks that will add tests using these.
-var _ = bytes.NewBuffer
-var _ = context.Background
-var _ = errors.Is
-var _ = fmt.Sprint
-var _ = http.MethodGet
-var _ = httptest.NewServer
-var _ = os.Open
-var _ = filepath.Join
-var _ = strings.TrimSpace
-var _ atomic.Int32
+// sha256 of "good-bytes"
+const goodBytes = "good-bytes"
+const goodSHA256 = "d79d9fd44ad034758fbdc3b2fa305894e98f111aae32efeb2c70a3b97cd0a456"
+
+func TestRun_HashMatchSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+
+	dest := t.TempDir()
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m", ExpectedHash: goodSHA256, HashAlgo: "sha256"}},
+		dest, 1, "", "", nil,
+	)
+	if results[0].Err != nil {
+		t.Fatalf("err = %v", results[0].Err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, "x.jar"))
+	if string(got) != goodBytes {
+		t.Fatalf("file = %q", got)
+	}
+}
+
+func TestRun_HashMismatchRetriesAndFails(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		fmt.Fprint(w, "wrong-bytes")
+	}))
+	defer srv.Close()
+
+	dest := t.TempDir()
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m", ExpectedHash: goodSHA256, HashAlgo: "sha256"}},
+		dest, 1, "", "", nil,
+	)
+	if !errors.Is(results[0].Err, ErrHashMismatch) {
+		t.Fatalf("err = %v, want ErrHashMismatch", results[0].Err)
+	}
+	if hits.Load() != int32(maxRetries) {
+		t.Fatalf("hits = %d, want %d", hits.Load(), maxRetries)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "x.jar")); !os.IsNotExist(err) {
+		t.Fatal("dest file should not exist after mismatch")
+	}
+}
+
+func TestRun_EmptyAlgoSkipsValidation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "anything")
+	}))
+	defer srv.Close()
+	dest := t.TempDir()
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m"}},
+		dest, 1, "", "", nil,
+	)
+	if results[0].Err != nil {
+		t.Fatalf("err = %v", results[0].Err)
+	}
+}

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -101,3 +101,63 @@ func TestRun_EmptyAlgoSkipsValidation(t *testing.T) {
 		t.Fatalf("err = %v", results[0].Err)
 	}
 }
+
+func TestRun_CacheHit_ValidatesAndReplaces(t *testing.T) {
+	var serverHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHits.Add(1)
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	dest := t.TempDir()
+
+	modDir := filepath.Join(cache, "m")
+	if err := os.MkdirAll(modDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modDir, "x.jar"), []byte("corrupt"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m", ExpectedHash: goodSHA256, HashAlgo: "sha256"}},
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatalf("err = %v", results[0].Err)
+	}
+	if serverHits.Load() == 0 {
+		t.Fatal("expected server to be contacted after cache invalidation")
+	}
+	got, _ := os.ReadFile(filepath.Join(dest, "x.jar"))
+	if string(got) != goodBytes {
+		t.Fatalf("dest = %q", got)
+	}
+	cached, _ := os.ReadFile(filepath.Join(modDir, "x.jar"))
+	if string(cached) != goodBytes {
+		t.Fatalf("cache not replaced: %q", cached)
+	}
+}
+
+func TestRun_CacheHit_ValidMatches(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be contacted")
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	dest := t.TempDir()
+	modDir := filepath.Join(cache, "m")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "x.jar"), []byte(goodBytes), 0644)
+
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m", ExpectedHash: goodSHA256, HashAlgo: "sha256"}},
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatalf("err = %v", results[0].Err)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -33,6 +33,7 @@ type LatestResult struct {
 	Filename string
 	URL      string
 	IsAPI    bool
+	Digest   string // raw "sha256:..." from the chosen release asset
 }
 
 const releasesPerPage = 25
@@ -196,6 +197,7 @@ func selectLatestResult(releases []Release, token string, allowPre bool) (*Lates
 			Filename: strings.TrimSpace(asset.Name),
 			URL:      downloadURL,
 			IsAPI:    isAPI,
+			Digest:   asset.Digest,
 		}
 	}
 

--- a/internal/maven/maven.go
+++ b/internal/maven/maven.go
@@ -133,3 +133,30 @@ func SanitizeComponent(s string) string {
 func MavenFilename(modName, version string) string {
 	return SanitizeComponent(modName) + "-" + SanitizeComponent(version) + ".jar"
 }
+
+// FetchSHA256 fetches the `<jarURL>.sha256` sidecar and returns the lowercase
+// hex digest. A 404 returns ("", nil) so callers can degrade gracefully.
+func FetchSHA256(ctx context.Context, jarURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jarURL+".sha256", nil)
+	if err != nil {
+		return "", fmt.Errorf("creating sha256 request: %w", err)
+	}
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching sha256 sidecar: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("sha256 sidecar HTTP %d", resp.StatusCode)
+	}
+	buf := make([]byte, 256)
+	n, _ := resp.Body.Read(buf)
+	s := strings.TrimSpace(string(buf[:n]))
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.ToLower(s), nil
+}

--- a/internal/maven/maven_test.go
+++ b/internal/maven/maven_test.go
@@ -2,6 +2,7 @@ package maven
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -119,5 +120,45 @@ func TestDownloadURL(t *testing.T) {
 	}
 	if !strings.Contains(url, "/My%20Mod/1.2.3/My-Mod-1.2.3.jar") {
 		t.Fatalf("unexpected url: %s", url)
+	}
+}
+
+func TestFetchSHA256(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok.jar.sha256":
+			fmt.Fprint(w, "ABCDEF0123  ok.jar\n")
+		case "/bare.jar.sha256":
+			fmt.Fprint(w, "deadbeef\n")
+		case "/missing.jar.sha256":
+			http.NotFound(w, r)
+		default:
+			http.Error(w, "unexpected", 500)
+		}
+	}))
+	defer srv.Close()
+	oldClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = oldClient }()
+
+	got, err := FetchSHA256(context.Background(), srv.URL+"/ok.jar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "abcdef0123" {
+		t.Fatalf("ok = %q, want abcdef0123", got)
+	}
+
+	got, err = FetchSHA256(context.Background(), srv.URL+"/bare.jar")
+	if err != nil || got != "deadbeef" {
+		t.Fatalf("bare = %q err=%v", got, err)
+	}
+
+	got, err = FetchSHA256(context.Background(), srv.URL+"/missing.jar")
+	if err != nil {
+		t.Fatalf("missing should not error, got %v", err)
+	}
+	if got != "" {
+		t.Fatalf("missing = %q, want \"\"", got)
 	}
 }

--- a/internal/modrinth/modrinth.go
+++ b/internal/modrinth/modrinth.go
@@ -33,11 +33,18 @@ func SetVersion(v string) {
 	UserAgent = "github.com/caedis/gtnh-daily-updater/" + v
 }
 
+// FileHashes holds the cryptographic hashes for a Modrinth file.
+type FileHashes struct {
+	SHA1   string `json:"sha1"`
+	SHA512 string `json:"sha512"`
+}
+
 // File represents a file attached to a Modrinth version.
 type File struct {
-	URL      string `json:"url"`
-	Filename string `json:"filename"`
-	Primary  bool   `json:"primary"`
+	URL      string     `json:"url"`
+	Filename string     `json:"filename"`
+	Primary  bool       `json:"primary"`
+	Hashes   FileHashes `json:"hashes"`
 }
 
 // Version represents a Modrinth project version.

--- a/internal/modrinth/modrinth_test.go
+++ b/internal/modrinth/modrinth_test.go
@@ -3,6 +3,7 @@ package modrinth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -225,5 +226,29 @@ func TestProjectExists(t *testing.T) {
 	}
 	if ok, err := ProjectExists(context.Background(), "missing"); err != nil || ok {
 		t.Errorf("ProjectExists(missing) = (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
+func TestVersion_FilesHashes(t *testing.T) {
+	body := `{"id":"v1","project_id":"p","version_number":"1.0","version_type":"release","loaders":["forge"],"game_versions":["1.12.2"],"files":[{"url":"http://x/x.jar","filename":"x.jar","primary":true,"hashes":{"sha1":"aa","sha512":"bb"}}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+	oldBase := baseURL
+	oldClient := httpClient
+	baseURL = srv.URL
+	httpClient = srv.Client()
+	defer func() { baseURL = oldBase; httpClient = oldClient }()
+
+	v, err := FetchVersion(context.Background(), "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Files) == 0 || v.Files[0].Hashes.SHA512 != "bb" {
+		t.Fatalf("SHA512 = %q, want bb", v.Files[0].Hashes.SHA512)
+	}
+	if v.Files[0].Hashes.SHA1 != "aa" {
+		t.Fatalf("SHA1 = %q, want aa", v.Files[0].Hashes.SHA1)
 	}
 }

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -26,27 +26,31 @@ import (
 
 // resolveModDownload resolves the download URL and filename for a mod, trying
 // extra downloads, --latest GitHub downloads, GitHub auth/public, and Maven in order.
-func resolveModDownload(db *assets.AssetsDB, modName, version, githubToken string, extraDownloads, latestDownloads map[string]resolvedExtra) (dl downloader.Download, ok bool) {
+func resolveModDownload(ctx context.Context, db *assets.AssetsDB, modName, version, githubToken string, extraDownloads, latestDownloads map[string]resolvedExtra) (dl downloader.Download, ok bool) {
 	// Extra mod with pre-resolved download info
 	if dlInfo, isExtra := extraDownloads[modName]; isExtra {
 		dl := downloader.Download{
-			URL:         dlInfo.URL,
-			Filename:    dlInfo.Filename,
-			ModName:     modName,
-			IsGitHubAPI: dlInfo.IsGitHubAPI,
+			URL:          dlInfo.URL,
+			Filename:     dlInfo.Filename,
+			ModName:      modName,
+			IsGitHubAPI:  dlInfo.IsGitHubAPI,
+			ExpectedHash: dlInfo.ExpectedHash,
+			HashAlgo:     dlInfo.HashAlgo,
 		}
-		return withMavenFallback(dl, db, modName, version), true
+		return withMavenFallback(ctx, dl, db, modName, version), true
 	}
 
 	// --latest resolved from GitHub directly
 	if dlInfo, found := latestDownloads[modName]; found {
 		dl := downloader.Download{
-			URL:         dlInfo.URL,
-			Filename:    dlInfo.Filename,
-			ModName:     modName,
-			IsGitHubAPI: dlInfo.IsGitHubAPI,
+			URL:          dlInfo.URL,
+			Filename:     dlInfo.Filename,
+			ModName:      modName,
+			IsGitHubAPI:  dlInfo.IsGitHubAPI,
+			ExpectedHash: dlInfo.ExpectedHash,
+			HashAlgo:     dlInfo.HashAlgo,
 		}
-		return withMavenFallback(dl, db, modName, version), true
+		return withMavenFallback(ctx, dl, db, modName, version), true
 	}
 
 	// GitHub with auth
@@ -58,7 +62,7 @@ func resolveModDownload(db *assets.AssetsDB, modName, version, githubToken strin
 				ModName:     modName,
 				IsGitHubAPI: true,
 			}
-			return withMavenFallback(dl, db, modName, version), true
+			return withMavenFallback(ctx, dl, db, modName, version), true
 		}
 	}
 
@@ -69,24 +73,25 @@ func resolveModDownload(db *assets.AssetsDB, modName, version, githubToken strin
 			Filename: filename,
 			ModName:  modName,
 		}
-		return withMavenFallback(dl, db, modName, version), true
+		return withMavenFallback(ctx, dl, db, modName, version), true
 	}
 
 	// Maven fallback for GTNH-hosted mods
 	if db.IsGTNH(modName) {
 		if mavenURL, mavenFn := maven.DownloadURL(modName, version); mavenURL != "" && mavenFn != "" {
-			return downloader.Download{
-				URL:      mavenURL,
-				Filename: mavenFn,
-				ModName:  modName,
-			}, true
+			d := downloader.Download{URL: mavenURL, Filename: mavenFn, ModName: modName}
+			if sha, _ := maven.FetchSHA256(ctx, mavenURL); sha != "" {
+				d.ExpectedHash = sha
+				d.HashAlgo = "sha256"
+			}
+			return d, true
 		}
 	}
 
 	return downloader.Download{}, false
 }
 
-func withMavenFallback(dl downloader.Download, db *assets.AssetsDB, modName, version string) downloader.Download {
+func withMavenFallback(ctx context.Context, dl downloader.Download, db *assets.AssetsDB, modName, version string) downloader.Download {
 	if !db.IsGTNH(modName) || !isGitHubDownload(dl.URL, dl.IsGitHubAPI) {
 		return dl
 	}
@@ -95,6 +100,9 @@ func withMavenFallback(dl downloader.Download, db *assets.AssetsDB, modName, ver
 		return dl
 	}
 	dl.MavenFallbackURL = mavenURL
+	if sha, _ := maven.FetchSHA256(ctx, mavenURL); sha != "" {
+		dl.MavenFallbackHash = sha
+	}
 	return dl
 }
 

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -304,10 +304,12 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 		if db.IsGTNH(name) {
 			mavenURL, mavenFn := maven.DownloadURL(name, version)
 			logging.Debugf("Verbose: extra mod %s using maven download filename=%s\n", name, mavenFn)
-			return diff.ResolvedExtraMod{Version: version, Side: modSide}, resolvedExtra{
-				URL:      mavenURL,
-				Filename: mavenFn,
-			}, nil
+			extra := resolvedExtra{URL: mavenURL, Filename: mavenFn}
+			if sha, _ := maven.FetchSHA256(ctx, mavenURL); sha != "" {
+				extra.ExpectedHash = sha
+				extra.HashAlgo = "sha256"
+			}
+			return diff.ResolvedExtraMod{Version: version, Side: modSide}, extra, nil
 		}
 
 		url, filename, isAPI, err := db.ResolveDownload(name, version)
@@ -356,10 +358,12 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 
 		version := strconv.Itoa(file.ID)
 		logging.Debugf("Verbose: extra mod %s CurseForge project=%d file=%d filename=%s\n", name, projectID, file.ID, file.FileName)
-		return diff.ResolvedExtraMod{Version: version, Side: modSide}, resolvedExtra{
-			URL:      downloadURL,
-			Filename: file.FileName,
-		}, nil
+		extra := resolvedExtra{URL: downloadURL, Filename: file.FileName}
+		if sha := file.SHA1(); sha != "" {
+			extra.ExpectedHash = sha
+			extra.HashAlgo = "sha1"
+		}
+		return diff.ResolvedExtraMod{Version: version, Side: modSide}, extra, nil
 
 	case strings.HasPrefix(spec.Source, "modrinth:"):
 		rest := strings.TrimPrefix(spec.Source, "modrinth:")
@@ -384,10 +388,12 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 		}
 
 		logging.Debugf("Verbose: extra mod %s Modrinth project=%s version=%s filename=%s\n", name, project, ver.ID, file.Filename)
-		return diff.ResolvedExtraMod{Version: ver.ID, Side: modSide}, resolvedExtra{
-			URL:      file.URL,
-			Filename: file.Filename,
-		}, nil
+		extra := resolvedExtra{URL: file.URL, Filename: file.Filename}
+		if file.Hashes.SHA512 != "" {
+			extra.ExpectedHash = file.Hashes.SHA512
+			extra.HashAlgo = "sha512"
+		}
+		return diff.ResolvedExtraMod{Version: ver.ID, Side: modSide}, extra, nil
 
 	case strings.HasPrefix(spec.Source, "github:"):
 		repo := strings.TrimPrefix(spec.Source, "github:")
@@ -459,11 +465,12 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 			return diff.ResolvedExtraMod{}, resolvedExtra{}, fmt.Errorf("release asset %s has no download URL", asset.Name)
 		}
 		logging.Debugf("Verbose: extra mod %s GitHub release=%s asset=%s\n", name, version, asset.Name)
-		return diff.ResolvedExtraMod{Version: version, Side: modSide}, resolvedExtra{
-			URL:         downloadURL,
-			Filename:    asset.Name,
-			IsGitHubAPI: isGitHubAPI,
-		}, nil
+		extra := resolvedExtra{URL: downloadURL, Filename: asset.Name, IsGitHubAPI: isGitHubAPI}
+		if d := strings.TrimPrefix(asset.Digest, "sha256:"); d != "" && d != asset.Digest {
+			extra.ExpectedHash = d
+			extra.HashAlgo = "sha256"
+		}
+		return diff.ResolvedExtraMod{Version: version, Side: modSide}, extra, nil
 
 	default:
 		// Direct URL source

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -264,11 +264,16 @@ func resolveLatestVersions(ctx context.Context, db *assets.AssetsDB, changes []d
 			if changes[r.idx].Type == diff.Unchanged {
 				changes[r.idx].Type = diff.Updated
 			}
-			latestDownloads[changes[r.idx].Name] = resolvedExtra{
+			extra := resolvedExtra{
 				URL:         r.result.URL,
 				Filename:    r.result.Filename,
 				IsGitHubAPI: r.result.IsAPI,
 			}
+			if d := strings.TrimPrefix(r.result.Digest, "sha256:"); d != "" && d != r.result.Digest {
+				extra.ExpectedHash = d
+				extra.HashAlgo = "sha256"
+			}
+			latestDownloads[changes[r.idx].Name] = extra
 		}
 	}
 

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	}
 
 	needsDownload := selectDownloadChanges(changes)
-	downloads, err := resolveDownloadsForChanges(needsDownload, db, opts, extraDownloads, latestDownloads)
+	downloads, err := resolveDownloadsForChanges(ctx, needsDownload, db, opts, extraDownloads, latestDownloads)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	if err := snapshotAndUpdateConfigsIfNeeded(ctx, state, gameDir, result, rollback, effectiveConfigVersion); err != nil {
 		return nil, err
 	}
-	if err := persistUpdatedState(state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion, result); err != nil {
+	if err := persistUpdatedState(ctx, state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion, result); err != nil {
 		return nil, err
 	}
 

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -43,7 +43,10 @@ type UpdateResult struct {
 
 // resolvedExtra holds download info for an extra mod resolved before download.
 type resolvedExtra struct {
-	URL         string
-	Filename    string
-	IsGitHubAPI bool
+	URL               string
+	Filename          string
+	IsGitHubAPI       bool
+	ExpectedHash      string
+	HashAlgo          string
+	MavenFallbackHash string
 }

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -207,12 +207,12 @@ func selectDownloadChanges(changes []diff.ModChange) []diff.ModChange {
 	return needsDownload
 }
 
-func resolveDownloadsForChanges(needsDownload []diff.ModChange, db *assets.AssetsDB, opts Options, extraDownloads, latestDownloads map[string]resolvedExtra) ([]downloader.Download, error) {
+func resolveDownloadsForChanges(ctx context.Context, needsDownload []diff.ModChange, db *assets.AssetsDB, opts Options, extraDownloads, latestDownloads map[string]resolvedExtra) ([]downloader.Download, error) {
 	var downloads []downloader.Download
 	var unresolved []string
 
 	for _, c := range needsDownload {
-		dl, ok := resolveModDownload(db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads)
+		dl, ok := resolveModDownload(ctx, db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads)
 		if !ok {
 			unresolved = append(unresolved, c.Name)
 			continue
@@ -368,12 +368,12 @@ func snapshotAndUpdateConfigsIfNeeded(ctx context.Context, state *config.LocalSt
 	return nil
 }
 
-func persistUpdatedState(state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error, configVersion string, result *UpdateResult) error {
+func persistUpdatedState(ctx context.Context, state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error, configVersion string, result *UpdateResult) error {
 	for _, c := range changes {
 		switch c.Type {
 		case diff.Added, diff.Updated:
 			filename := ""
-			if dl, ok := resolveModDownload(db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads); ok {
+			if dl, ok := resolveModDownload(ctx, db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads); ok {
 				filename = dl.Filename
 			}
 			state.Mods[c.Name] = config.InstalledMod{

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -305,10 +306,17 @@ func downloadMods(ctx context.Context, downloads []downloader.Download, needsDow
 	logging.Infoln()
 
 	var failed []string
+	var hashFailed []string
 	for _, r := range results {
 		if r.Err != nil {
 			failed = append(failed, fmt.Sprintf("%s: %v", r.Download.Filename, r.Err))
+			if errors.Is(r.Err, downloader.ErrHashMismatch) {
+				hashFailed = append(hashFailed, r.Download.Filename)
+			}
 		}
+	}
+	if len(hashFailed) > 0 {
+		return rollback(fmt.Errorf("hash validation failed after 3 retries for: %s (all download errors: %s)", strings.Join(hashFailed, ", "), strings.Join(failed, "; ")))
 	}
 	if len(failed) > 0 {
 		return rollback(fmt.Errorf("download failures: %s", strings.Join(failed, "; ")))


### PR DESCRIPTION
## Summary
- Validate per-source hash on every mod download (sha256 for GitHub + Maven sidecar, sha1 for CurseForge, sha512 for Modrinth)
- Retry up to 3 times on mismatch via existing backoff; fatal abort the run after final failure
- Cache hits also validated; corrupt cache entries deleted and refetched
- Sources without a known hash (assets DB GitHub path, direct URL extras) skip validation gracefully

## Test plan
- [x] go test ./...
- [x] go vet ./...
- [x] Manual: run update on a real instance, confirm normal flow unaffected
- [x] Manual: temporarily corrupt a cached jar, rerun, confirm refetch