### PR TITLE
feat: detect and preserve .disabled mods

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -43,6 +43,10 @@ type Download struct {
 	HashAlgo string
 	// MavenFallbackHash is the expected sha256 for MavenFallbackURL. Empty disables on fallback.
 	MavenFallbackHash string
+	// Disabled writes the on-disk file with a `.disabled` suffix (Prism/MultiMC
+	// disabled-mod convention). The cache entry still uses the clean filename so
+	// it stays shareable with enabled installs.
+	Disabled bool
 }
 
 type Result struct {
@@ -165,7 +169,11 @@ func downloadFileWithRetryURL(ctx context.Context, dl Download, destDir, githubT
 func downloadFile(ctx context.Context, dl Download, destDir, githubToken, cacheDir string) error {
 	safeFilename := fileutil.SanitizeFilename(dl.Filename)
 	safeModName := fileutil.SanitizeFilename(dl.ModName)
-	destPath := filepath.Join(destDir, safeFilename)
+	destName := safeFilename
+	if dl.Disabled {
+		destName += ".disabled"
+	}
+	destPath := filepath.Join(destDir, destName)
 	logging.Debugf("Verbose: download start mod=%s filename=%s url=%s\n", dl.ModName, dl.Filename, dl.URL)
 
 	// Check cache first

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -44,6 +44,39 @@ func TestNewHasher_Algos(t *testing.T) {
 const goodBytes = "good-bytes"
 const goodSHA256 = "d79d9fd44ad034758fbdc3b2fa305894e98f111aae32efeb2c70a3b97cd0a456"
 
+func TestRun_DisabledWritesDisabledDestButCachesClean(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, goodBytes)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	dest := t.TempDir()
+	results := Run(context.Background(),
+		[]Download{{URL: srv.URL, Filename: "x.jar", ModName: "m", Disabled: true}},
+		dest, 1, "", cache, nil,
+	)
+	if results[0].Err != nil {
+		t.Fatalf("err = %v", results[0].Err)
+	}
+
+	// On-disk mod keeps the .disabled suffix.
+	if got, _ := os.ReadFile(filepath.Join(dest, "x.jar.disabled")); string(got) != goodBytes {
+		t.Fatalf("disabled dest file = %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "x.jar")); !os.IsNotExist(err) {
+		t.Fatalf("plain .jar should not exist, stat err=%v", err)
+	}
+
+	// Cache is keyed on the clean filename so it stays shareable.
+	if _, err := os.Stat(filepath.Join(cache, "m", "x.jar")); err != nil {
+		t.Fatalf("clean cache entry missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cache, "m", "x.jar.disabled")); !os.IsNotExist(err) {
+		t.Fatalf("cache should not hold .disabled variant, stat err=%v", err)
+	}
+}
+
 func TestRun_HashMatchSucceeds(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, goodBytes)

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -501,6 +501,111 @@ func TestRun_GitHubDownloadFailureFallsBackToMaven(t *testing.T) {
 	}
 }
 
+func TestRun_UpdatesDisabledModKeepsDisabledSuffix(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	const oldJar = "TestMod-1.0.0.jar.disabled"
+	if err := os.WriteFile(filepath.Join(instanceDir, "mods", oldJar), []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	state := &config.LocalState{
+		Side:          "client",
+		ManifestDate:  "2026-02-19",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version":       "daily",
+				"last_version":  "daily-previous",
+				"last_updated":  "2026-02-20",
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"TestMod": map[string]any{"version": "2.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{
+					map[string]any{
+						"name":           "TestMod",
+						"latest_version": "2.0.0",
+						"source":         "",
+						"side":           "BOTH",
+						"versions": []any{
+							map[string]any{
+								"version_tag":          "2.0.0",
+								"filename":             "TestMod-2.0.0.jar",
+								"download_url":         "https://example.test/TestMod-2.0.0.jar",
+								"browser_download_url": "https://example.test/TestMod-2.0.0.jar",
+								"prerelease":           false,
+							},
+							map[string]any{
+								"version_tag":          "1.0.0",
+								"filename":             "TestMod-1.0.0.jar",
+								"download_url":         "https://example.test/TestMod-1.0.0.jar",
+								"browser_download_url": "https://example.test/TestMod-1.0.0.jar",
+								"prerelease":           false,
+							},
+						},
+					},
+				},
+			})
+		case "/TestMod-2.0.0.jar":
+			if _, err := w.Write([]byte("new")); err != nil {
+				t.Fatalf("writing jar response: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restoreClient := rewriteDefaultHTTPClient(t, server)
+	defer restoreClient()
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		NoCache:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Updated != 1 || result.Added != 0 || result.Removed != 0 {
+		t.Fatalf("unexpected summary: %+v", result)
+	}
+
+	// Old disabled jar gone.
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", oldJar)); !os.IsNotExist(err) {
+		t.Fatalf("old disabled jar still exists, stat err=%v", err)
+	}
+	// New jar keeps the disabled suffix and never appears enabled.
+	newJar := filepath.Join(instanceDir, "mods", "TestMod-2.0.0.jar.disabled")
+	if data, err := os.ReadFile(newJar); err != nil || string(data) != "new" {
+		t.Fatalf("new disabled jar contents=%q err=%v", string(data), err)
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-2.0.0.jar")); !os.IsNotExist(err) {
+		t.Fatalf("enabled jar should not exist, stat err=%v", err)
+	}
+
+	updatedState, err := config.Load(instanceDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if got := updatedState.Mods["TestMod"]; got.Filename != "TestMod-2.0.0.jar.disabled" || got.Version != "2.0.0" {
+		t.Fatalf("unexpected tracked mod: %+v", got)
+	}
+}
+
 func TestResolveExtraMod_GitHubSourceUsesAPIURLWithToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/repos/owner/repo/releases/latest" {

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	}
 
 	needsDownload := selectDownloadChanges(changes)
-	downloads, err := resolveDownloadsForChanges(ctx, needsDownload, db, opts, extraDownloads, latestDownloads)
+	downloads, err := resolveDownloadsForChanges(ctx, needsDownload, db, opts, extraDownloads, latestDownloads, state.Mods)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/updater/scan.go
+++ b/internal/updater/scan.go
@@ -32,13 +32,13 @@ func scanInstalledMods(modsDir string, filenameIdx map[string][]assets.FilenameM
 			return nil
 		}
 
-		if filepath.Ext(d.Name()) != ".jar" {
+		fn := d.Name()
+		lookup, ok := jarLookupName(fn)
+		if !ok {
 			return nil
 		}
 
-		fn := d.Name()
-
-		matches := filenameIdx[fn]
+		matches := filenameIdx[lookup]
 		if len(matches) == 0 {
 			logging.Debugf("Verbose: unmatched jar skipped during scan: %s\n", fn)
 			return nil
@@ -81,6 +81,27 @@ func scanInstalledMods(modsDir string, filenameIdx map[string][]assets.FilenameM
 	return mods, nil
 }
 
+// disabledSuffix is appended to mod filenames by Prism/MultiMC to disable a mod
+// without deleting it (e.g. "SomeMod-1.2.3.jar.disabled").
+const disabledSuffix = ".disabled"
+
+// jarLookupName returns the assets-DB lookup key for an on-disk mod file. It
+// accepts plain `.jar` files and `.jar.disabled` files, returning the
+// underlying `.jar` name. The second return is false for any other file.
+func jarLookupName(filename string) (string, bool) {
+	name := strings.TrimSuffix(filename, disabledSuffix)
+	if filepath.Ext(name) != ".jar" {
+		return "", false
+	}
+	return name, true
+}
+
+// isDisabledFilename reports whether an on-disk mod filename carries the
+// disabled suffix.
+func isDisabledFilename(filename string) bool {
+	return strings.HasSuffix(filename, ".jar"+disabledSuffix)
+}
+
 // pickBestMatch selects the best filename match when there are multiple candidates.
 // It prefers mods that are in the current manifest.
 func pickBestMatch(matches []assets.FilenameMatch, manifestMods map[string]manifest.ModInfo) assets.FilenameMatch {
@@ -110,7 +131,8 @@ func buildVersionPattern(filename, version string) (*regexp.Regexp, bool) {
 	escaped := regexp.QuoteMeta(filename)
 	escapedVer := regexp.QuoteMeta(version)
 	patStr := strings.Replace(escaped, escapedVer, `.*`, 1)
-	return regexp.MustCompile(`(?i)^` + patStr + `$`), true
+	// Allow an optional trailing `.disabled` so manually disabled jars match too.
+	return regexp.MustCompile(`(?i)^` + patStr + `(?:` + regexp.QuoteMeta(disabledSuffix) + `)?$`), true
 }
 
 // detectStaleJars finds disk jars that belong to manifest mods not yet present
@@ -197,7 +219,7 @@ func listTopLevelJarFiles(modsDir string) (map[string]bool, error) {
 		if d.IsDir() {
 			return filepath.SkipDir
 		}
-		if filepath.Ext(d.Name()) == ".jar" {
+		if _, ok := jarLookupName(d.Name()); ok {
 			files[d.Name()] = true
 		}
 		return nil

--- a/internal/updater/updater_helpers_test.go
+++ b/internal/updater/updater_helpers_test.go
@@ -50,6 +50,24 @@ func TestListTopLevelJarFiles(t *testing.T) {
 	}
 }
 
+func TestListTopLevelJarFilesIncludesDisabled(t *testing.T) {
+	modsDir := t.TempDir()
+	for _, fn := range []string{"on.jar", "off.jar.disabled", "note.txt", "off.txt.disabled"} {
+		if err := os.WriteFile(filepath.Join(modsDir, fn), []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) failed: %v", fn, err)
+		}
+	}
+
+	files, err := listTopLevelJarFiles(modsDir)
+	if err != nil {
+		t.Fatalf("listTopLevelJarFiles failed: %v", err)
+	}
+
+	if len(files) != 2 || !files["on.jar"] || !files["off.jar.disabled"] {
+		t.Fatalf("unexpected top-level jar files: %+v", files)
+	}
+}
+
 func TestScanInstalledMods(t *testing.T) {
 	modsDir := t.TempDir()
 	for _, fn := range []string{"a.jar", "b.jar", "c.jar", "dup.jar", "unmatched.jar"} {
@@ -107,6 +125,32 @@ func TestScanInstalledMods(t *testing.T) {
 	}
 }
 
+func TestScanInstalledModsDetectsDisabled(t *testing.T) {
+	modsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(modsDir, "c.jar.disabled"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	filenameIdx := map[string][]assets.FilenameMatch{
+		"c.jar": {
+			{ModName: "client-mod", Version: "1.0.0", Side: "CLIENT"},
+		},
+	}
+
+	mods, err := scanInstalledMods(modsDir, filenameIdx, nil, nil, "client")
+	if err != nil {
+		t.Fatalf("scanInstalledMods failed: %v", err)
+	}
+
+	got, ok := mods["client-mod"]
+	if !ok {
+		t.Fatalf("disabled mod not detected: %+v", mods)
+	}
+	if got.Version != "1.0.0" || got.Filename != "c.jar.disabled" {
+		t.Fatalf("unexpected entry: %+v", got)
+	}
+}
+
 func TestBuildVersionPattern(t *testing.T) {
 	tests := []struct {
 		filename    string
@@ -119,8 +163,8 @@ func TestBuildVersionPattern(t *testing.T) {
 			filename:    "buildcraft-7.1.55.jar",
 			version:     "7.1.55",
 			wantOk:      true,
-			wantMatch:   []string{"buildcraft-7.1.55.jar", "buildcraft-CUSTOMBUILD.jar", "buildcraft-7.1.99.jar", "BUILDCRAFT-7.1.55.jar"},
-			wantNoMatch: []string{"BuildCraftCompat-7.1.20.jar", "BuildCraftOilTweak-1.1.3.jar"},
+			wantMatch:   []string{"buildcraft-7.1.55.jar", "buildcraft-CUSTOMBUILD.jar", "buildcraft-7.1.99.jar", "BUILDCRAFT-7.1.55.jar", "buildcraft-7.1.99.jar.disabled"},
+			wantNoMatch: []string{"BuildCraftCompat-7.1.20.jar", "BuildCraftOilTweak-1.1.3.jar", "buildcraft-7.1.99.jar.bak"},
 		},
 		{
 			filename: "mod-1.0.0.jar",

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -208,7 +208,7 @@ func selectDownloadChanges(changes []diff.ModChange) []diff.ModChange {
 	return needsDownload
 }
 
-func resolveDownloadsForChanges(ctx context.Context, needsDownload []diff.ModChange, db *assets.AssetsDB, opts Options, extraDownloads, latestDownloads map[string]resolvedExtra) ([]downloader.Download, error) {
+func resolveDownloadsForChanges(ctx context.Context, needsDownload []diff.ModChange, db *assets.AssetsDB, opts Options, extraDownloads, latestDownloads map[string]resolvedExtra, installedMods map[string]config.InstalledMod) ([]downloader.Download, error) {
 	var downloads []downloader.Download
 	var unresolved []string
 
@@ -217,6 +217,10 @@ func resolveDownloadsForChanges(ctx context.Context, needsDownload []diff.ModCha
 		if !ok {
 			unresolved = append(unresolved, c.Name)
 			continue
+		}
+		// Preserve a manually disabled mod's `.disabled` suffix across updates.
+		if isDisabledFilename(installedMods[c.Name].Filename) {
+			dl.Disabled = true
 		}
 		downloads = append(downloads, dl)
 		logging.Debugf(
@@ -380,9 +384,14 @@ func persistUpdatedState(ctx context.Context, state *config.LocalState, changes 
 	for _, c := range changes {
 		switch c.Type {
 		case diff.Added, diff.Updated:
+			// Capture disabled state before the entry is overwritten below.
+			wasDisabled := isDisabledFilename(state.Mods[c.Name].Filename)
 			filename := ""
 			if dl, ok := resolveModDownload(ctx, db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads); ok {
 				filename = dl.Filename
+				if wasDisabled {
+					filename += disabledSuffix
+				}
 			}
 			state.Mods[c.Name] = config.InstalledMod{
 				Version:  c.NewVersion,


### PR DESCRIPTION
Closes #45 

## What

Treat `.jar.disabled` (Prism/MultiMC convention) files as installed mods.

## Why

A manually disabled mod was invisible to the scanner, so each update re-downloaded it as an enabled `.jar`. Now:

- Manually disabled mod is detected as installed, not re-added
- On update, the new version keeps the `.disabled` suffix and the old version is removed
- Download cache stays keyed on the clean filename, so it remains shareable between enabled and disabled installs

## Changes

- **scan**: `jarLookupName`/`isDisabledFilename` helpers; `scanInstalledMods` matches the base jar name and stores the real on-disk filename
- **scan**: `listTopLevelJarFiles` and `buildVersionPattern` handle `.disabled` variants (covers `--latest` preserve path + stale-jar detection)
- **downloader**: `Download.Disabled` writes the dest with `.disabled` suffix while caching under the clean name
- **pipeline**: disabled state threaded through `resolveDownloadsForChanges` and `persistUpdatedState`

## Tests

TDD, red-first: downloader dest/cache, list-includes-disabled, version-pattern, scan-detect, and a full-pipeline update test asserting old removed + new kept disabled + state filename.


Tested by disabling hodgepodge and updating. Jar was updated, but was kept disabled. An update to date  jar was kept the same and was not readded.