### PR TITLE
fix: expand leading ~ in path flags and profiles

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,11 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		// Expand a leading "~" in path flags; a quoted "~/..." argument is
+		// never expanded by the shell and would otherwise be treated as a
+		// literal directory name relative to the working directory.
+		expandFlagPaths()
+
 		if logFile == "" {
 			if logsDir, err := paths.LogsDir(); err == nil {
 				logFile = filepath.Join(logsDir, time.Now().Format("2006-01-02_15-04-05")+".log")
@@ -153,6 +158,16 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&profileName, "profile", "", "Load a saved option profile by name")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write command output to a log file")
+}
+
+// expandFlagPaths expands a leading "~" in the path-valued global flags to the
+// user's home directory. Shells only expand an unquoted "~", so a quoted
+// argument like "~/.local/share" reaches the program literally.
+func expandFlagPaths() {
+	instanceDir = paths.ExpandTilde(instanceDir)
+	logFile = paths.ExpandTilde(logFile)
+	cacheDir = paths.ExpandTilde(cacheDir)
+	cacheDirAll = paths.ExpandTilde(cacheDirAll)
 }
 
 func getGithubToken() string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,10 +2,39 @@ package cmd
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestExpandFlagPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	instanceDir = "~/.local/share/instances/foo"
+	logFile = "~/logs/run.log"
+	cacheDir = "~/cache"
+	cacheDirAll = ".local/relative"
+	t.Cleanup(func() {
+		instanceDir, logFile, cacheDir, cacheDirAll = ".", "", "", ""
+	})
+
+	expandFlagPaths()
+
+	if want := filepath.Join(home, ".local", "share", "instances", "foo"); instanceDir != want {
+		t.Errorf("instanceDir = %q, want %q", instanceDir, want)
+	}
+	if want := filepath.Join(home, "logs", "run.log"); logFile != want {
+		t.Errorf("logFile = %q, want %q", logFile, want)
+	}
+	if want := filepath.Join(home, "cache"); cacheDir != want {
+		t.Errorf("cacheDir = %q, want %q", cacheDir, want)
+	}
+	if cacheDirAll != ".local/relative" {
+		t.Errorf("cacheDirAll = %q, want unchanged relative path", cacheDirAll)
+	}
+}
 
 func TestUsageArgsWrapsValidationErrors(t *testing.T) {
 	wrapped := usageArgs(cobra.ExactArgs(1))

--- a/internal/paths/expand.go
+++ b/internal/paths/expand.go
@@ -1,0 +1,31 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ExpandTilde expands a leading "~" (alone or followed by a path separator)
+// to the current user's home directory. Shells only expand an unquoted "~",
+// so a quoted argument like "~/.local/share" reaches the program literally;
+// this restores the expected behavior.
+//
+// "~user" syntax is not supported and is returned unchanged, as is any path
+// where "~" is not the leading element.
+func ExpandTilde(p string) string {
+	if p == "" || p[0] != '~' {
+		return p
+	}
+	if p == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return p
+	}
+	if p[1] == '/' || p[1] == os.PathSeparator {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}

--- a/internal/paths/expand_test.go
+++ b/internal/paths/expand_test.go
@@ -1,0 +1,38 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare tilde", "~", home},
+		{"tilde slash", "~/", home},
+		{"tilde path", "~/.local/share", filepath.Join(home, ".local", "share")},
+		{"empty", "", ""},
+		{"absolute unchanged", "/home/ethan/.local", "/home/ethan/.local"},
+		{"relative unchanged", ".local/share", ".local/share"},
+		{"tilde mid-path unchanged", "foo/~/bar", "foo/~/bar"},
+		{"tilde user unchanged", "~ethan/.local", "~ethan/.local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandTilde(tt.in)
+			if got != tt.want {
+				t.Errorf("ExpandTilde(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -53,6 +53,14 @@ func Load(name string) (*Profile, error) {
 		}
 	}
 
+	// Expand a leading "~" in stored path values; profiles are hand-editable
+	// and a quoted "~" in the source is never expanded by the shell.
+	for _, ptr := range []*string{p.InstanceDir, p.CacheDir, p.LogFile} {
+		if ptr != nil {
+			*ptr = paths.ExpandTilde(*ptr)
+		}
+	}
+
 	return &p, nil
 }
 

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,38 @@
+package profile
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadExpandsTildePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	inst := "~/instances/foo"
+	cache := "~/cache/mods"
+	logf := "~/logs/run.log"
+	p := &Profile{InstanceDir: &inst, CacheDir: &cache, LogFile: &logf}
+	if err := Save("tilde", p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := Load("tilde")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	wantInst := filepath.Join(home, "instances", "foo")
+	if got.InstanceDir == nil || *got.InstanceDir != wantInst {
+		t.Errorf("InstanceDir = %v, want %q", got.InstanceDir, wantInst)
+	}
+	wantCache := filepath.Join(home, "cache", "mods")
+	if got.CacheDir == nil || *got.CacheDir != wantCache {
+		t.Errorf("CacheDir = %v, want %q", got.CacheDir, wantCache)
+	}
+	wantLog := filepath.Join(home, "logs", "run.log")
+	if got.LogFile == nil || *got.LogFile != wantLog {
+		t.Errorf("LogFile = %v, want %q", got.LogFile, wantLog)
+	}
+}


### PR DESCRIPTION
## Problem

Quoted `"~/path"` arguments reach the program literally since the shell only expands an unquoted `~`. The literal `~` was then joined relative to cwd, producing broken paths like `/home/user/~/...`.

## Fix

- `internal/paths/expand.go` - new `ExpandTilde()`. Expands leading `~` / `~/...` to home dir. Leaves `~user`, mid-path `~`, and relative paths alone.
- `cmd/root.go` - `expandFlagPaths()` in `PersistentPreRunE` expands `instance-dir`, `log-file`, `cache-dir`, and the `update-all` cache flag.
- `internal/profile/profile.go` - `Load()` expands stored `instance-dir`/`cache-dir`/`log-file` (covers `update-all` per-profile paths).

## Tests

Written test-first (TDD). Cover the helper, profile load, and flag wiring. Full suite + `go vet` + `gofmt` clean. Verified end-to-end: `--instance-dir "~/inst"` loads state from `$HOME/inst`.

Closes #46