### PR TITLE
fix(gitconfigs): use real merge to stop config re-merge churn

### DIFF
--- a/internal/gitconfigs/gitconfigs.go
+++ b/internal/gitconfigs/gitconfigs.go
@@ -133,9 +133,13 @@ func Snapshot(ctx context.Context, gameDir, side string) error {
 
 // ApplyUpdate fetches the new pack version and merges it into the local branch
 // (pack wins on genuine conflicts), then copies updated files back to the instance.
-func ApplyUpdate(ctx context.Context, gameDir, side, newConfigVersion string) error {
+//
+// prevConfigVersion is the version currently applied to the instance; it is used
+// to re-baseline repos created before real merges were adopted (see
+// ensureBaseRecorded). Pass "" to skip re-baselining.
+func ApplyUpdate(ctx context.Context, gameDir, side, prevConfigVersion, newConfigVersion string) error {
 	repoDir := ConfigRepoDir(gameDir)
-	logging.Debugf("Verbose: gitconfigs apply-update gameDir=%q side=%s newVersion=%s\n", gameDir, side, newConfigVersion)
+	logging.Debugf("Verbose: gitconfigs apply-update gameDir=%q side=%s prevVersion=%s newVersion=%s\n", gameDir, side, prevConfigVersion, newConfigVersion)
 
 	// Unshallow if the repo was previously cloned with --depth 1.
 	// A shallow repo has no common ancestor visible, causing every file to be
@@ -153,22 +157,13 @@ func ApplyUpdate(ctx context.Context, gameDir, side, newConfigVersion string) er
 		return fmt.Errorf("fetching tag %s: %w", newConfigVersion, err)
 	}
 
-	// Merge — pack wins on genuine conflicts; user changes on untouched lines are preserved
-	logging.Debugf("Verbose: gitconfigs merging %s (pack wins on genuine conflicts)\n", newConfigVersion)
-	mergeErr := runGit(ctx, repoDir, "merge", "--squash", "-X", "theirs", newConfigVersion)
-	if mergeErr != nil {
-		// `-X theirs` does not auto-resolve modify/delete conflicts. Apply the
-		// same pack-wins rule to those entries; if anything else is unmerged,
-		// surface the original error.
-		if resolveErr := resolveRemainingConflicts(ctx, repoDir); resolveErr != nil {
-			return fmt.Errorf("merging config update: %w (%v)", mergeErr, resolveErr)
-		}
-	}
+	// One-time re-baseline for repos built by the old squash merges, so this
+	// update bases off the previously applied version rather than the clone root.
+	ensureBaseRecorded(ctx, repoDir, prevConfigVersion)
 
-	logStagedDiff(ctx, repoDir)
 	msg := fmt.Sprintf("Update configs to %s", newConfigVersion)
-	if err := runGit(ctx, repoDir, "commit", "--allow-empty", "-m", msg); err != nil {
-		return fmt.Errorf("committing config update: %w", err)
+	if err := mergePackVersion(ctx, repoDir, newConfigVersion, msg); err != nil {
+		return err
 	}
 	logging.Debugf("Verbose: gitconfigs merge committed, replacing instance files\n")
 
@@ -193,6 +188,81 @@ func ApplyUpdate(ctx context.Context, gameDir, side, newConfigVersion string) er
 	logging.Debugf("Verbose: gitconfigs apply-update complete\n")
 
 	return nil
+}
+
+// mergePackVersion merges ref into the current branch (pack wins on genuine
+// conflicts) and commits the result with msg.
+//
+// This is a real merge (not --squash) on purpose. A squash merge never records
+// ref as a parent of the local branch, so the next update's merge-base falls
+// all the way back to the original clone commit. Against that frozen base, every
+// section the pack or the game has reordered since init looks like an add/add
+// (or modify/modify) delta and gets re-applied on every run — e.g. duplicated
+// config blocks that the game strips on launch, only to be re-added next update.
+// A real merge keeps ref in the ancestry so the base advances to the last
+// applied version each run, and pack-vs-local only diffs against what changed.
+//
+// --no-commit lets us resolve leftover modify/delete conflicts and log the
+// staged diff before finalizing; the follow-up commit completes the merge.
+func mergePackVersion(ctx context.Context, repoDir, ref, msg string) error {
+	logging.Debugf("Verbose: gitconfigs merging %s (pack wins on genuine conflicts)\n", ref)
+	mergeErr := runGit(ctx, repoDir, "merge", "--no-commit", "--no-ff", "-X", "theirs", ref)
+	if mergeErr != nil {
+		// `-X theirs` does not auto-resolve modify/delete conflicts. Apply the
+		// same pack-wins rule to those entries; if anything else is unmerged,
+		// surface the original error.
+		if resolveErr := resolveRemainingConflicts(ctx, repoDir); resolveErr != nil {
+			return fmt.Errorf("merging config update: %w (%v)", mergeErr, resolveErr)
+		}
+	}
+
+	logStagedDiff(ctx, repoDir)
+	// --allow-empty: an unchanged pack still records the merge so the base advances.
+	if err := runGit(ctx, repoDir, "commit", "--no-edit", "--allow-empty", "-m", msg); err != nil {
+		return fmt.Errorf("committing config update: %w", err)
+	}
+	return nil
+}
+
+// ensureBaseRecorded grafts the previously applied pack version into the local
+// branch's ancestry when it is missing, so the upcoming merge bases off that
+// version instead of the original clone commit.
+//
+// Repos created before the switch from squash to real merges have no pack tag in
+// their history (squash merges record no parent), which froze the merge-base at
+// the clone point and re-applied the pack's whole delta every run. A one-time
+// `merge -s ours` records the previous tag as a parent without changing any
+// tracked file, so the next merge sees the correct base. Repos created after the
+// switch already have the tag in history and hit the is-ancestor fast path.
+//
+// Best-effort: if the previous tag is gone upstream (pruned nightly) or anything
+// else fails, it logs and returns — the merge then falls back to the old
+// frozen-base behavior for this one run, which is no worse than before.
+func ensureBaseRecorded(ctx context.Context, repoDir, prevConfigVersion string) {
+	if prevConfigVersion == "" {
+		return
+	}
+	commitish := prevConfigVersion + "^{commit}"
+
+	// Make the previous tag's commit available locally (older runs may have GC'd it).
+	if _, err := runGitOutput(ctx, repoDir, "rev-parse", "-q", "--verify", commitish); err != nil {
+		if ferr := runGit(ctx, repoDir, "fetch", "--no-tags", "origin", "tag", prevConfigVersion); ferr != nil {
+			logging.Debugf("Verbose: gitconfigs re-baseline skipped, cannot fetch %s: %v\n", prevConfigVersion, ferr)
+			return
+		}
+	}
+
+	// Already in ancestry → real-merge repos and fresh inits land here; nothing to do.
+	if err := runGit(ctx, repoDir, "merge-base", "--is-ancestor", commitish, "HEAD"); err == nil {
+		return
+	}
+
+	logging.Debugf("Verbose: gitconfigs re-baselining: grafting %s into history (one-time)\n", prevConfigVersion)
+	msg := fmt.Sprintf("Re-baseline onto %s", prevConfigVersion)
+	// -s ours keeps our tree verbatim and only records prevConfigVersion as a parent.
+	if err := runGit(ctx, repoDir, "merge", "-s", "ours", "--no-ff", "--no-edit", "-m", msg, commitish); err != nil {
+		logging.Debugf("Verbose: gitconfigs re-baseline graft failed (continuing): %v\n", err)
+	}
 }
 
 // resolveRemainingConflicts handles conflict types left over by `merge -X theirs`

--- a/internal/gitconfigs/gitconfigs.go
+++ b/internal/gitconfigs/gitconfigs.go
@@ -20,6 +20,11 @@ const (
 	GitUserEmail = "gtnh-daily-updater@localhost"
 )
 
+// gitignoreEntries are paths the config repo should never track (churning logs).
+var gitignoreEntries = []string{
+	"journeymap/journeymap.log",
+}
+
 // ConfigRepoDir returns the path to the git repo inside gameDir.
 func ConfigRepoDir(gameDir string) string {
 	return filepath.Join(gameDir, RepoDir)
@@ -95,6 +100,10 @@ func Init(ctx context.Context, instanceDir, gameDir, side, configVersion string)
 		return fmt.Errorf("copying configs to repo: %w", err)
 	}
 
+	if err := ensureGitignore(ctx, repoDir); err != nil {
+		return err
+	}
+
 	// Commit the local state
 	if err := runGit(ctx, repoDir, "add", "-A"); err != nil {
 		return fmt.Errorf("staging files: %w", err)
@@ -117,6 +126,10 @@ func Snapshot(ctx context.Context, gameDir, side string) error {
 
 	if err := copyTrackedItemsToRepo(gameDir, repoDir, side); err != nil {
 		return fmt.Errorf("copying configs to repo: %w", err)
+	}
+
+	if err := ensureGitignore(ctx, repoDir); err != nil {
+		return err
 	}
 
 	if err := runGit(ctx, repoDir, "add", "-A"); err != nil {
@@ -550,4 +563,44 @@ func copyTrackedItemsToRepo(gameDir, repoDir, side string) error {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// ensureGitignore makes sure the repo's .gitignore lists gitignoreEntries and
+// untracks any entry already committed (so churning logs stop being snapshotted).
+func ensureGitignore(ctx context.Context, repoDir string) error {
+	path := filepath.Join(repoDir, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading .gitignore: %w", err)
+	}
+
+	lines := make(map[string]bool)
+	for l := range strings.SplitSeq(string(existing), "\n") {
+		lines[strings.TrimSpace(l)] = true
+	}
+
+	content := string(existing)
+	for _, entry := range gitignoreEntries {
+		if lines[entry] {
+			continue
+		}
+		if content != "" && !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += entry + "\n"
+	}
+
+	if content != string(existing) {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("writing .gitignore: %w", err)
+		}
+	}
+
+	// Untrack entries that were committed before being ignored.
+	for _, entry := range gitignoreEntries {
+		if err := runGit(ctx, repoDir, "rm", "--cached", "--ignore-unmatch", "--", entry); err != nil {
+			return fmt.Errorf("untracking %s: %w", entry, err)
+		}
+	}
+	return nil
 }

--- a/internal/gitconfigs/gitconfigs_test.go
+++ b/internal/gitconfigs/gitconfigs_test.go
@@ -255,6 +255,246 @@ func TestResolveBothModifiedConflicts(t *testing.T) {
 	}
 }
 
+// TestMergeAdvancesBaseNoDuplication reproduces the config-churn bug. The clone
+// point (v1) lacks a config block; the pack adds it at v2 (and leaves it
+// untouched at v3); the game reorders that block on every launch. With a squash
+// merge the base stays frozen at v1, so on the v3 update the pack's copy of the
+// block (relative to a base that lacks it) is re-added beside the player's moved
+// copy — two blocks. mergePackVersion uses a real merge, advancing the base to
+// v2, so the v3 update sees no pack change and keeps a single block.
+func TestMergeAdvancesBaseNoDuplication(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	cfg := filepath.Join(dir, "config", "Client.cfg")
+	noBlock := "header\n\ntail=on\n"                            // v1: clone point, no block
+	packBlock := "header\n\nblock {\n    val=1\n}\n\ntail=on\n" // v2/v3: pack adds block
+	gameForm := "block {\n    val=1\n}\n\nheader\n\ntail=on\n"  // game reorders block to top
+
+	// v1: clone point without the block.
+	writeFile(t, cfg, noBlock)
+	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "commit", "-m", "pack v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "tag", "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// v2: pack introduces the block. v3: pack leaves it untouched.
+	writeFile(t, cfg, packBlock)
+	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "commit", "-m", "pack v2 adds block"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "tag", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "config", "other.cfg"), "v3\n") // unrelated change so v3 differs
+	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "commit", "-m", "pack v3"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "tag", "v3"); err != nil {
+		t.Fatal(err)
+	}
+
+	// local branch starts at the clone point (v1).
+	if err := runGit(ctx, dir, "checkout", "-b", "local", "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	blockCount := func() int {
+		t.Helper()
+		b, err := os.ReadFile(cfg)
+		if err != nil {
+			t.Fatalf("read cfg: %v", err)
+		}
+		return strings.Count(string(b), "block {")
+	}
+	gameRewriteAndSnapshot := func() {
+		t.Helper()
+		writeFile(t, cfg, gameForm)
+		if err := runGit(ctx, dir, "add", "-A"); err != nil {
+			t.Fatal(err)
+		}
+		if err := runGit(ctx, dir, "commit", "-m", "Snapshot player changes"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Round 1: update to v2 (pack adds the block), then the game reorders it.
+	if err := mergePackVersion(ctx, dir, "v2", "Update configs to v2"); err != nil {
+		t.Fatalf("merge v2: %v", err)
+	}
+	if n := blockCount(); n != 1 {
+		t.Fatalf("after v2 update: block count = %d, want 1", n)
+	}
+	gameRewriteAndSnapshot()
+
+	// Round 2: update to v3. Pack never touched Client.cfg since v2. A frozen
+	// base (v1, no block) would re-add the pack's block beside the player's
+	// reordered one (count 2); a real merge advances the base to v2 (count 1).
+	if err := mergePackVersion(ctx, dir, "v3", "Update configs to v3"); err != nil {
+		t.Fatalf("merge v3: %v", err)
+	}
+	if n := blockCount(); n != 1 {
+		t.Fatalf("after v3 update: block count = %d, want 1 (duplication regression)", n)
+	}
+
+	// The merge-base must have advanced past the clone point (v1) to v3.
+	base, err := runGitOutput(ctx, dir, "merge-base", "local", "v3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3, err := runGitOutput(ctx, dir, "rev-parse", "v3^{commit}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(base) != strings.TrimSpace(v3) {
+		t.Fatalf("merge-base = %s, want v3 %s (base did not advance)", strings.TrimSpace(base), strings.TrimSpace(v3))
+	}
+}
+
+// TestEnsureBaseRecordedRebaselinesSquashRepo simulates an existing repo built
+// by the old squash merges (no pack tag in its ancestry, base frozen at the
+// clone root). ensureBaseRecorded should graft the previously applied tag into
+// history so the next real merge bases off it — yielding a single block instead
+// of the duplicate the frozen base would produce.
+func TestEnsureBaseRecordedRebaselinesSquashRepo(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	cfg := filepath.Join(dir, "config", "Client.cfg")
+	noBlock := "header\n\ntail=on\n"
+	packBlock := "header\n\nblock {\n    val=1\n}\n\ntail=on\n"
+	gameForm := "block {\n    val=1\n}\n\nheader\n\ntail=on\n"
+
+	commit := func(msg string) {
+		t.Helper()
+		if err := runGit(ctx, dir, "add", "-A"); err != nil {
+			t.Fatal(err)
+		}
+		if err := runGit(ctx, dir, "commit", "-m", msg); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile(t, cfg, noBlock)
+	commit("pack v1")
+	if err := runGit(ctx, dir, "tag", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, cfg, packBlock)
+	commit("pack v2 adds block")
+	if err := runGit(ctx, dir, "tag", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "config", "other.cfg"), "v3\n")
+	commit("pack v3")
+	if err := runGit(ctx, dir, "tag", "v3"); err != nil {
+		t.Fatal(err)
+	}
+
+	// local built by the OLD squash path: branch at v1, squash-merge v2 (records
+	// no parent), then the game reorders the block and we snapshot.
+	if err := runGit(ctx, dir, "checkout", "-b", "local", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "merge", "--squash", "-X", "theirs", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	commit("Update configs to v2")
+	writeFile(t, cfg, gameForm)
+	commit("Snapshot player changes")
+
+	// Sanity: v2 is NOT yet in local's ancestry (squash recorded no parent).
+	if err := runGit(ctx, dir, "merge-base", "--is-ancestor", "v2^{commit}", "HEAD"); err == nil {
+		t.Fatal("precondition failed: v2 should not be an ancestor of squash-built local")
+	}
+
+	// Re-baseline, then apply the v3 update the normal (real-merge) way.
+	ensureBaseRecorded(ctx, dir, "v2")
+	if err := mergePackVersion(ctx, dir, "v3", "Update configs to v3"); err != nil {
+		t.Fatalf("merge v3: %v", err)
+	}
+
+	b, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(b), "block {"); n != 1 {
+		t.Fatalf("after re-baseline + v3 update: block count = %d, want 1", n)
+	}
+
+	// Base must now reach v3 (via the grafted v2), not the clone root.
+	base, err := runGitOutput(ctx, dir, "merge-base", "local", "v3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3, err := runGitOutput(ctx, dir, "rev-parse", "v3^{commit}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(base) != strings.TrimSpace(v3) {
+		t.Fatalf("merge-base = %s, want v3 %s", strings.TrimSpace(base), strings.TrimSpace(v3))
+	}
+}
+
+// TestEnsureBaseRecordedNoopWhenAncestor verifies the fast path: when the
+// previous tag is already in the local branch's history (repos created after the
+// switch to real merges), ensureBaseRecorded creates no graft commit.
+func TestEnsureBaseRecordedNoopWhenAncestor(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	writeFile(t, filepath.Join(dir, "config", "a.cfg"), "x\n")
+	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "commit", "-m", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "tag", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "checkout", "-b", "local"); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := runGitOutput(ctx, dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// v1 is an ancestor of local → must be a no-op.
+	ensureBaseRecorded(ctx, dir, "v1")
+	after, err := runGitOutput(ctx, dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(before) != strings.TrimSpace(after) {
+		t.Fatalf("ensureBaseRecorded created a commit on the fast path: %s -> %s", before, after)
+	}
+}
+
 func TestResolveRemainingConflicts(t *testing.T) {
 	if !IsGitAvailable() {
 		t.Skip("git not available")

--- a/internal/gitconfigs/gitconfigs_test.go
+++ b/internal/gitconfigs/gitconfigs_test.go
@@ -536,3 +536,80 @@ func TestResolveRemainingConflicts(t *testing.T) {
 		t.Fatalf("shared.cfg = %q, want pack-version", got)
 	}
 }
+
+func TestEnsureGitignoreCreatesAndAppends(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	// No .gitignore yet: should be created with all entries.
+	if err := ensureGitignore(ctx, dir); err != nil {
+		t.Fatalf("ensureGitignore: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	for _, entry := range gitignoreEntries {
+		if !strings.Contains(string(got), entry) {
+			t.Fatalf(".gitignore missing %q, got:\n%s", entry, got)
+		}
+	}
+
+	// Pre-existing content without trailing newline: entry appended on its own line.
+	writeFile(t, filepath.Join(dir, ".gitignore"), "*.tmp")
+	if err := ensureGitignore(ctx, dir); err != nil {
+		t.Fatalf("ensureGitignore append: %v", err)
+	}
+	got, _ = os.ReadFile(filepath.Join(dir, ".gitignore"))
+	want := "*.tmp\n" + gitignoreEntries[0] + "\n"
+	if string(got) != want {
+		t.Fatalf(".gitignore = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureGitignoreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	if err := ensureGitignore(ctx, dir); err != nil {
+		t.Fatalf("first ensureGitignore: %v", err)
+	}
+	first, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err := ensureGitignore(ctx, dir); err != nil {
+		t.Fatalf("second ensureGitignore: %v", err)
+	}
+	second, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if string(first) != string(second) {
+		t.Fatalf("not idempotent: %q vs %q", first, second)
+	}
+}
+
+func TestEnsureGitignoreUntracksCommittedLog(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	// Commit the log before it is ignored.
+	writeFile(t, filepath.Join(dir, "journeymap", "journeymap.log"), "old log\n")
+	if err := runGit(ctx, dir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, dir, "commit", "-m", "tracked log"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureGitignore(ctx, dir); err != nil {
+		t.Fatalf("ensureGitignore: %v", err)
+	}
+
+	// Log must no longer be tracked.
+	out, err := runGitOutput(ctx, dir, "ls-files", "journeymap/journeymap.log")
+	if err != nil {
+		t.Fatalf("ls-files: %v", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("journeymap.log still tracked: %q", out)
+	}
+}

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -373,7 +373,9 @@ func snapshotAndUpdateConfigsIfNeeded(ctx context.Context, state *config.LocalSt
 	}
 
 	logging.Infoln("Updating configs...")
-	if err := gitconfigs.ApplyUpdate(ctx, gameDir, state.Side, configVersion); err != nil {
+	// state.ConfigVersion is still the previously applied version here (it is
+	// advanced to configVersion later, in persistUpdatedState).
+	if err := gitconfigs.ApplyUpdate(ctx, gameDir, state.Side, state.ConfigVersion, configVersion); err != nil {
 		return rollback(fmt.Errorf("applying config update: %w", err))
 	}
 	result.ConfigUpdated = true


### PR DESCRIPTION
Squash merges recorded no parent, so merge-base stayed frozen at the
clone commit. Against that stale base, blocks the pack added and the
game later reordered looked like two non-overlapping adds and were
duplicated on every update; the game stripped the dupe on launch and
the next update re-added it, churning the same configs indefinitely.

- ApplyUpdate now does a real merge (--no-ff -X theirs) so the applied
  tag enters history and the base advances each run
- ensureBaseRecorded grafts the previously applied tag via merge -s
  ours (zero file changes) to re-baseline old squash-built repos once
- thread prevConfigVersion through ApplyUpdate from state.ConfigVersion

Add .gitignore and ignore journeymap.log