### PR TITLE
fix(updater): stop re-downloading special-char mods

### DIFF
--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/maven"
 	"github.com/caedis/gtnh-daily-updater/internal/semver"
 )
@@ -167,29 +168,49 @@ type FilenameMatch struct {
 	ModName string
 	Version string
 	Side    string
+	// RawFilename is the canonical assets-DB filename this match was indexed
+	// under, before any cross-OS sanitization. Recording it lets the updater
+	// recompute the expected on-disk name if the sanitization rules change,
+	// renaming an existing jar instead of re-downloading a duplicate.
+	RawFilename string
 }
 
 // BuildFilenameIndex creates a reverse index from jar filename to mod name + version.
 // For duplicate filenames, all matches are returned. For GTNH-hosted mods (Source == ""),
 // Maven-style filenames (ModName-Version.jar) are also indexed.
+//
+// Each raw filename is additionally indexed under its sanitized form (see
+// fileutil.SanitizeFilename) so that a jar written to disk with a cross-OS-safe
+// name still resolves back to its mod on the next scan. The match's RawFilename
+// always carries the canonical (pre-sanitization) name.
 func (db *AssetsDB) BuildFilenameIndex() map[string][]FilenameMatch {
 	idx := make(map[string][]FilenameMatch)
+	add := func(rawName string, mod AssetEntry, v VersionAsset) {
+		if rawName == "" {
+			return
+		}
+		match := FilenameMatch{
+			ModName:     mod.Name,
+			Version:     v.VersionTag,
+			Side:        mod.Side,
+			RawFilename: rawName,
+		}
+		// Index under every name this jar may carry on disk (raw, current
+		// sanitized form, and legacy sanitized forms) so a file written by any
+		// past sanitization rule still resolves back to its mod.
+		for _, key := range fileutil.FilenameVariants(rawName) {
+			idx[key] = append(idx[key], match)
+		}
+	}
 	for _, mod := range db.Mods {
 		isGTNH := mod.Source == ""
 		for _, v := range mod.Versions {
-			match := FilenameMatch{
-				ModName: mod.Name,
-				Version: v.VersionTag,
-				Side:    mod.Side,
-			}
-			if v.Filename != "" {
-				idx[v.Filename] = append(idx[v.Filename], match)
-			}
+			add(v.Filename, mod, v)
 			// Also index the Maven-style filename for GTNH-hosted mods
 			if isGTNH {
 				mavenFn := maven.MavenFilename(mod.Name, v.VersionTag)
 				if mavenFn != v.Filename {
-					idx[mavenFn] = append(idx[mavenFn], match)
+					add(mavenFn, mod, v)
 				}
 			}
 		}

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1,0 +1,77 @@
+package assets
+
+import (
+	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
+)
+
+// TestBuildFilenameIndexSanitizedKeys verifies the reverse index maps the raw
+// assets-DB filename, its current sanitized form, and its legacy sanitized form
+// back to the same mod, each carrying the canonical raw filename. This is what
+// lets a jar written to disk under any past sanitization rule be recognized on
+// the next scan instead of being re-downloaded.
+func TestBuildFilenameIndexSanitizedKeys(t *testing.T) {
+	// Apostrophe + spaces are kept by the current rule but were dropped/hyphenated
+	// by the legacy rule, so the legacy on-disk name differs from raw.
+	raw := "Biomes O' Plenty-1.0.0.jar"
+	variants := fileutil.FilenameVariants(raw)
+	if len(variants) < 2 {
+		t.Fatalf("test precondition: expected raw and a legacy variant, got %v", variants)
+	}
+
+	db := &AssetsDB{
+		Mods: []AssetEntry{
+			{
+				Name:   "BiomesOPlenty",
+				Source: "external", // non-GTNH: no maven alias
+				Versions: []VersionAsset{
+					{VersionTag: "1.0.0", Filename: raw},
+				},
+			},
+		},
+	}
+	db.BuildIndex()
+
+	idx := db.BuildFilenameIndex()
+
+	for _, key := range variants {
+		matches := idx[key]
+		if len(matches) != 1 {
+			t.Fatalf("index[%q]: expected 1 match, got %d (%+v)", key, len(matches), matches)
+		}
+		m := matches[0]
+		if m.ModName != "BiomesOPlenty" || m.Version != "1.0.0" {
+			t.Errorf("index[%q]: unexpected match %+v", key, m)
+		}
+		if m.RawFilename != raw {
+			t.Errorf("index[%q]: RawFilename=%q, want %q", key, m.RawFilename, raw)
+		}
+	}
+}
+
+// TestBuildFilenameIndexCleanNameNoDuplicate verifies a filename that needs no
+// sanitization produces a single index entry, not a duplicate.
+func TestBuildFilenameIndexCleanNameNoDuplicate(t *testing.T) {
+	clean := "lwjgl3ify-2.1.5.jar"
+	db := &AssetsDB{
+		Mods: []AssetEntry{
+			{
+				Name:   "lwjgl3ify",
+				Source: "external",
+				Versions: []VersionAsset{
+					{VersionTag: "2.1.5", Filename: clean},
+				},
+			},
+		},
+	}
+	db.BuildIndex()
+
+	idx := db.BuildFilenameIndex()
+	if len(idx[clean]) != 1 {
+		t.Fatalf("index[%q]: expected exactly 1 match, got %d", clean, len(idx[clean]))
+	}
+	if idx[clean][0].RawFilename != clean {
+		t.Errorf("RawFilename=%q, want %q", idx[clean][0].RawFilename, clean)
+	}
+}

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -31,6 +31,13 @@ type InstalledMod struct {
 	Version  string `json:"version"`
 	Filename string `json:"filename"`
 	Side     string `json:"side"`
+	// RawFilename is the canonical assets-DB filename, before cross-OS
+	// sanitization. Filename holds the actual on-disk name (which may be the
+	// sanitized form). Persisting both lets the updater migrate an existing jar
+	// when the sanitization rules change, instead of treating it as missing and
+	// re-downloading a duplicate. Empty for jars with no known canonical name
+	// (e.g. user-added or pre-migration state).
+	RawFilename string `json:"raw_filename,omitempty"`
 }
 
 // Load reads the local state from the instance directory.

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -8,26 +8,6 @@ import (
 	"strings"
 )
 
-// SanitizeFilename removes or replaces characters that are invalid in
-// filenames on Windows, macOS, or Linux. Only allows [a-zA-Z0-9._-],
-// converts spaces to hyphens, and drops everything else.
-func SanitizeFilename(s string) string {
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
-			b.WriteRune(r)
-		case r == '-' || r == '.' || r == '_' || r == '+':
-			b.WriteRune(r)
-		case r == ' ':
-			b.WriteRune('-')
-		default:
-			// skip invalid characters
-		}
-	}
-	return b.String()
-}
-
 // CopyFile copies a single file from src to dst, preserving permissions.
 // Parent directories of dst are created as needed.
 func CopyFile(src, dst string) error {

--- a/internal/fileutil/sanitize.go
+++ b/internal/fileutil/sanitize.go
@@ -1,0 +1,136 @@
+package fileutil
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// percentEncoded matches a single percent-encoded byte (e.g. "%2B").
+var percentEncoded = regexp.MustCompile(`%[0-9A-Fa-f]{2}`)
+
+// winReservedNames are device names reserved on Windows in every directory,
+// even with an extension (e.g. "NUL.jar" resolves to the NUL device).
+var winReservedNames = func() map[string]bool {
+	m := map[string]bool{"con": true, "prn": true, "aux": true, "nul": true}
+	for i := 1; i <= 9; i++ {
+		m["com"+strconv.Itoa(i)] = true
+		m["lpt"+strconv.Itoa(i)] = true
+	}
+	return m
+}()
+
+// isForbiddenRune reports whether r may not appear in a filename on Windows
+// (the strictest of the three target platforms). This is the union of the
+// reserved punctuation and all control characters; designing to it keeps names
+// valid on Linux and macOS too. See internal/fileutil docs / Microsoft's
+// "Naming Files, Paths, and Namespaces".
+func isForbiddenRune(r rune) bool {
+	if r < 0x20 {
+		return true
+	}
+	switch r {
+	case '<', '>', ':', '"', '/', '\\', '|', '?', '*':
+		return true
+	}
+	return false
+}
+
+// SanitizeFilename makes a filename safe to write on Windows, macOS, and Linux
+// while preserving the characters those platforms actually allow. It:
+//
+//  1. decodes percent-encoded bytes (e.g. "%2B" -> "+"), since an undecoded
+//     sequence means the name was never URL-decoded upstream;
+//  2. replaces Windows-forbidden characters (< > : " / \ | ? * and control
+//     chars) with "_";
+//  3. trims surrounding whitespace and strips trailing dots/spaces, which
+//     Windows disallows;
+//  4. prefixes "_" to Windows reserved device names (CON, NUL, COM1-9, ...).
+//
+// Characters that are legal on all three platforms — including spaces,
+// brackets, parentheses, apostrophes, +, -, ., _ — are kept as-is.
+//
+// Changing these rules is safe: the updater records each mod's canonical
+// (raw) filename and re-sanitizes on scan, renaming an existing jar to the new
+// form instead of re-downloading a duplicate. See FilenameVariants.
+func SanitizeFilename(s string) string {
+	// 1. Decode percent-encoded bytes before sanitizing, so a decoded byte that
+	// happens to be forbidden (e.g. %2F -> '/') is still caught below.
+	s = percentEncoded.ReplaceAllStringFunc(s, func(m string) string {
+		b, err := strconv.ParseUint(m[1:], 16, 8)
+		if err != nil {
+			return m
+		}
+		return string(rune(b))
+	})
+
+	// 2. Replace forbidden characters.
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isForbiddenRune(r) {
+			b.WriteByte('_')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+
+	// 3. Trim surrounding whitespace, then any trailing dots/spaces.
+	out := strings.TrimSpace(b.String())
+	out = strings.TrimRight(out, " .")
+
+	if out == "" {
+		return "_"
+	}
+
+	// 4. Guard Windows reserved device names (matched on the base name,
+	// case-insensitively).
+	base := out
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	if winReservedNames[strings.ToLower(base)] {
+		out = "_" + out
+	}
+
+	return out
+}
+
+// legacySanitizeFilename reproduces the original, stricter sanitization rule
+// (allow only [A-Za-z0-9._+-], spaces -> hyphens, drop everything else). It is
+// retained solely so FilenameVariants can recognize jars written to disk by
+// older releases and migrate them, rather than re-downloading duplicates.
+func legacySanitizeFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '-' || r == '.' || r == '_' || r == '+':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		default:
+			// drop
+		}
+	}
+	return b.String()
+}
+
+// FilenameVariants returns every on-disk name a canonical (raw) filename may
+// have been written as: the raw name itself, the current sanitized form, and
+// known historical sanitized forms. The reverse filename index keys on all of
+// them so a jar written by any past sanitization rule still resolves to its
+// mod. Duplicates and empty results are omitted; the raw name is always first.
+func FilenameVariants(raw string) []string {
+	out := []string{raw}
+	seen := map[string]bool{raw: true}
+	for _, v := range []string{SanitizeFilename(raw), legacySanitizeFilename(raw)} {
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/fileutil/sanitize_test.go
+++ b/internal/fileutil/sanitize_test.go
@@ -1,0 +1,90 @@
+package fileutil
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Legal-everywhere characters are now preserved.
+		{"brackets kept", "BiblioCraft[v1.11.7][MC1.7.10].jar", "BiblioCraft[v1.11.7][MC1.7.10].jar"},
+		{"apostrophe and spaces kept", "Biomes O' Plenty-1.0.0.jar", "Biomes O' Plenty-1.0.0.jar"},
+		{"parens kept", "Advanced Solar Panel (Unofficial)-1.0.jar", "Advanced Solar Panel (Unofficial)-1.0.jar"},
+		{"plus kept", "lwjgl3ify-2.1.5+forge.jar", "lwjgl3ify-2.1.5+forge.jar"},
+		{"clean name unchanged", "GT5-Unofficial-5.09.49.171.jar", "GT5-Unofficial-5.09.49.171.jar"},
+
+		// Percent-encodings are decoded before sanitization.
+		{"percent-encoded plus", "CraftPresence-2.0.0%2B1.7.10.jar", "CraftPresence-2.0.0+1.7.10.jar"},
+		{"lowercase percent hex", "mod-1.0%2b1.7.10.jar", "mod-1.0+1.7.10.jar"},
+
+		// Windows-forbidden characters are replaced with underscore.
+		{"colon replaced", "mod:weird-1.0.jar", "mod_weird-1.0.jar"},
+		{"slash replaced", "a/b-1.0.jar", "a_b-1.0.jar"},
+		{"pipe and star replaced", "a|b*c-1.0.jar", "a_b_c-1.0.jar"},
+		{"decoded slash replaced", "a%2Fb-1.0.jar", "a_b-1.0.jar"},
+
+		// Trailing dots/spaces stripped; leading/trailing space trimmed.
+		{"trailing space and dot", "  mod-1.0.jar . ", "mod-1.0.jar"},
+
+		// Windows reserved device names get a prefix.
+		{"reserved name", "NUL.jar", "_NUL.jar"},
+		{"reserved name case-insensitive", "con.jar", "_con.jar"},
+		{"reserved-like but distinct", "CONFIG.jar", "CONFIG.jar"},
+
+		// Degenerate inputs.
+		{"empty", "", "_"},
+		{"dots only", "..", "_"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeFilename(tc.in); got != tc.want {
+				t.Errorf("SanitizeFilename(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeFilenameControlChars(t *testing.T) {
+	if got := SanitizeFilename("mod\x00\x1f-1.0.jar"); got != "mod__-1.0.jar" {
+		t.Errorf("control chars not replaced: %q", got)
+	}
+}
+
+// TestFilenameVariants verifies the index-key generator returns the raw name,
+// the current sanitized form, and the legacy (older-rule) sanitized form, so a
+// jar written by any historical rule still resolves to its mod.
+func TestFilenameVariants(t *testing.T) {
+	raw := "Biomes O' Plenty-1.0.0.jar"
+	got := FilenameVariants(raw)
+
+	// raw is preserved as-is under the loosened rules.
+	if !slices.Contains(got, raw) {
+		t.Errorf("variants %v missing raw %q", got, raw)
+	}
+	// legacy rule dropped the apostrophe and turned spaces into hyphens.
+	const legacy = "Biomes-O-Plenty-1.0.0.jar"
+	if !slices.Contains(got, legacy) {
+		t.Errorf("variants %v missing legacy form %q", got, legacy)
+	}
+	// No duplicates.
+	seen := map[string]bool{}
+	for _, v := range got {
+		if seen[v] {
+			t.Errorf("variants contain duplicate %q: %v", v, got)
+		}
+		seen[v] = true
+	}
+}
+
+func TestFilenameVariantsCleanNameSingle(t *testing.T) {
+	raw := "lwjgl3ify-2.1.5.jar"
+	got := FilenameVariants(raw)
+	if len(got) != 1 || got[0] != raw {
+		t.Errorf("clean name should yield single variant, got %v", got)
+	}
+}

--- a/internal/maven/maven_test.go
+++ b/internal/maven/maven_test.go
@@ -114,11 +114,13 @@ func TestFetchMetadata(t *testing.T) {
 }
 
 func TestDownloadURL(t *testing.T) {
+	// Spaces are legal in filenames on all target platforms and are now
+	// preserved; the URL path components are percent-escaped separately.
 	url, filename := DownloadURL("My Mod", "1.2.3")
-	if filename != "My-Mod-1.2.3.jar" {
-		t.Fatalf("filename=%q want=My-Mod-1.2.3.jar", filename)
+	if filename != "My Mod-1.2.3.jar" {
+		t.Fatalf("filename=%q want=%q", filename, "My Mod-1.2.3.jar")
 	}
-	if !strings.Contains(url, "/My%20Mod/1.2.3/My-Mod-1.2.3.jar") {
+	if !strings.Contains(url, "/My%20Mod/1.2.3/My%20Mod-1.2.3.jar") {
 		t.Fatalf("unexpected url: %s", url)
 	}
 }

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -12,8 +12,95 @@ import (
 	"testing"
 
 	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 )
+
+// TestRun_SanitizedFilenameNotRedownloaded reproduces issue #49: a mod whose
+// canonical assets-DB filename contains characters stripped by an older
+// sanitization rule was written to disk under that legacy name, but the scan
+// keyed on the raw name failed to recognize it — so every run re-downloaded it.
+// The scan must resolve the legacy on-disk jar back to its mod and report it
+// Unchanged (dry-run leaves the file untouched).
+func TestRun_SanitizedFilenameNotRedownloaded(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	const rawJar = "Biomes O' Plenty-1.0.0.jar"
+	// Pick the legacy on-disk variant (apostrophe dropped, spaces hyphenated) an
+	// older release would have written.
+	var legacyJar string
+	for _, v := range fileutil.FilenameVariants(rawJar) {
+		if v != rawJar {
+			legacyJar = v
+			break
+		}
+	}
+	if legacyJar == "" {
+		t.Fatalf("test precondition: expected a legacy variant different from raw")
+	}
+	if err := os.WriteFile(filepath.Join(instanceDir, "mods", legacyJar), []byte("jar"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	state := &config.LocalState{
+		Side:          "client",
+		ManifestDate:  "2026-02-19",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	server := newUpdaterMockServer(t, mockManifestAndAssets{
+		manifest: map[string]any{
+			"version":       "daily",
+			"last_version":  "daily-previous",
+			"last_updated":  "2026-02-20",
+			"config":        "cfg-1",
+			"github_mods":   map[string]any{"BiomesOPlenty": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+			"external_mods": map[string]any{},
+		},
+		assets: map[string]any{
+			"config": map[string]any{"versions": []any{}},
+			"mods": []any{
+				map[string]any{
+					"name":           "BiomesOPlenty",
+					"latest_version": "1.0.0",
+					"source":         "https://example.test/mod",
+					"side":           "BOTH",
+					"versions": []any{
+						map[string]any{
+							"version_tag":          "1.0.0",
+							"filename":             rawJar,
+							"download_url":         "https://example.test/bop.jar",
+							"browser_download_url": "https://example.test/bop.jar",
+							"prerelease":           false,
+						},
+					},
+				},
+			},
+		},
+	})
+	defer server.Close()
+
+	restoreClient := rewriteDefaultHTTPClient(t, server)
+	defer restoreClient()
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		DryRun:      true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Added != 0 || result.Updated != 0 || result.Removed != 0 || result.Unchanged != 1 {
+		t.Fatalf("expected the sanitized jar to be recognized as unchanged, got summary: %+v", result)
+	}
+}
 
 func TestRun_DoesNotShortCircuitOnManifestTimestampWithLatest(t *testing.T) {
 	instanceDir := t.TempDir()
@@ -92,6 +179,121 @@ func TestRun_DoesNotShortCircuitOnManifestTimestampWithLatest(t *testing.T) {
 	}
 	if result.Updated != 1 || result.Added != 0 || result.Removed != 0 {
 		t.Fatalf("unexpected summary: %+v", result)
+	}
+}
+
+// TestRun_LegacyNamedJarMigratedNoDuplicate verifies that when an on-disk jar
+// carries a legacy-sanitized name, a real update migrates it (the old jar is
+// removed and the new one written under the current sanitized name) without
+// leaving a duplicate behind.
+func TestRun_LegacyNamedJarMigratedNoDuplicate(t *testing.T) {
+	instanceDir := t.TempDir()
+	modsDir := filepath.Join(instanceDir, "mods")
+	if err := os.MkdirAll(modsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	const rawOld = "Biomes O' Plenty-1.0.0.jar"
+	var legacyOld string
+	for _, v := range fileutil.FilenameVariants(rawOld) {
+		if v != rawOld {
+			legacyOld = v
+			break
+		}
+	}
+	if legacyOld == "" {
+		t.Fatalf("test precondition: expected a legacy variant for %q", rawOld)
+	}
+	if err := os.WriteFile(filepath.Join(modsDir, legacyOld), []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	// Empty state: the scan must discover the legacy jar via the index.
+	state := &config.LocalState{
+		Side:          "client",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	const newJar = "Biomes O' Plenty-2.0.0.jar"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version":       "daily",
+				"last_version":  "daily-previous",
+				"last_updated":  "2026-02-20",
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"BiomesOPlenty": map[string]any{"version": "2.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{
+					map[string]any{
+						"name":           "BiomesOPlenty",
+						"latest_version": "2.0.0",
+						"source":         "https://example.test/mod",
+						"side":           "BOTH",
+						"versions": []any{
+							map[string]any{
+								"version_tag":          "2.0.0",
+								"filename":             newJar,
+								"download_url":         "https://example.test/bop2.jar",
+								"browser_download_url": "https://example.test/bop2.jar",
+								"prerelease":           false,
+							},
+							map[string]any{
+								"version_tag":          "1.0.0",
+								"filename":             rawOld,
+								"download_url":         "https://example.test/bop1.jar",
+								"browser_download_url": "https://example.test/bop1.jar",
+								"prerelease":           false,
+							},
+						},
+					},
+				},
+			})
+		case "/bop2.jar":
+			if _, err := w.Write([]byte("new")); err != nil {
+				t.Fatalf("writing jar: %v", err)
+			}
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restoreClient := rewriteDefaultHTTPClient(t, server)
+	defer restoreClient()
+
+	result, err := Run(context.Background(), Options{InstanceDir: instanceDir, NoCache: true})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Updated != 1 || result.Added != 0 || result.Removed != 0 {
+		t.Fatalf("unexpected summary: %+v", result)
+	}
+
+	// New jar present with the current sanitized name and new content.
+	if data, err := os.ReadFile(filepath.Join(modsDir, newJar)); err != nil || string(data) != "new" {
+		t.Fatalf("new jar contents=%q err=%v", string(data), err)
+	}
+	// No leftover jars: exactly one file in mods/.
+	entries, err := os.ReadDir(modsDir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != newJar {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected only %q in mods dir, got %v", newJar, names)
 	}
 }
 

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -101,6 +101,11 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	if err := ensureModsDir(modsDir, rollback); err != nil {
 		return nil, err
 	}
+	// Migrate any tracked jar whose on-disk name no longer matches the current
+	// sanitization of its canonical filename (e.g. after a sanitization-rule
+	// change). Renaming in place avoids re-downloading a duplicate. Done only on
+	// a real run — never under --dry-run, which must not touch the filesystem.
+	reconcileSanitizedFilenames(state.Mods, modsDir)
 	if err := removeOutdatedJars(changes, state.Mods, modsDir, rollback); err != nil {
 		return nil, err
 	}

--- a/internal/updater/scan.go
+++ b/internal/updater/scan.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 	"github.com/caedis/gtnh-daily-updater/internal/side"
@@ -66,9 +67,10 @@ func scanInstalledMods(modsDir string, filenameIdx map[string][]assets.FilenameM
 		}
 
 		mods[match.ModName] = config.InstalledMod{
-			Version:  match.Version,
-			Filename: fn,
-			Side:     modSide,
+			Version:     match.Version,
+			Filename:    fn,
+			RawFilename: match.RawFilename,
+			Side:        modSide,
 		}
 		logging.Debugf("Verbose: scanned mod %s version=%s filename=%s side=%s\n", match.ModName, match.Version, fn, modSide)
 
@@ -135,6 +137,33 @@ func buildVersionPattern(filename, version string) (*regexp.Regexp, bool) {
 	return regexp.MustCompile(`(?i)^` + patStr + `(?:` + regexp.QuoteMeta(disabledSuffix) + `)?$`), true
 }
 
+// versionPatternsForFilename builds version-wildcard patterns for both the raw
+// filename and its sanitized on-disk form. Duplicate patterns (when the
+// filename needs no sanitization) are collapsed.
+func versionPatternsForFilename(filename, version string) []*regexp.Regexp {
+	var patterns []*regexp.Regexp
+	seen := make(map[string]bool)
+	for _, fn := range []string{filename, fileutil.SanitizeFilename(filename)} {
+		pat, ok := buildVersionPattern(fn, version)
+		if !ok || seen[pat.String()] {
+			continue
+		}
+		seen[pat.String()] = true
+		patterns = append(patterns, pat)
+	}
+	return patterns
+}
+
+// matchesAny reports whether s matches any of the patterns.
+func matchesAny(patterns []*regexp.Regexp, s string) bool {
+	for _, pat := range patterns {
+		if pat.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
 // detectStaleJars finds disk jars that belong to manifest mods not yet present
 // in scannedMods. It compares each unresolved mod's expected filename pattern
 // against unclaimed jars. Mods are processed in reverse alphabetical order so
@@ -180,22 +209,26 @@ func detectStaleJars(
 		if !ok {
 			continue
 		}
-		pat, ok := buildVersionPattern(filename, info.Version)
-		if !ok {
+		// Match both the canonical filename and its sanitized on-disk form, so a
+		// jar this tool wrote with a cross-OS-safe name is still recognized as
+		// stale (and later removed/replaced) rather than left orphaned.
+		patterns := versionPatternsForFilename(filename, info.Version)
+		if len(patterns) == 0 {
 			continue
 		}
 		for _, jar := range jarList {
 			if claimedJars[jar] {
 				continue
 			}
-			if pat.MatchString(jar) {
+			if matchesAny(patterns, jar) {
 				result[modName] = config.InstalledMod{
-					Version:  "",
-					Filename: jar,
-					Side:     info.Side,
+					Version:     "",
+					Filename:    jar,
+					RawFilename: filename,
+					Side:        info.Side,
 				}
 				claimedJars[jar] = true
-				logging.Debugf("Verbose: stale jar detected mod=%s pattern=%s matched=%s\n", modName, pat.String(), jar)
+				logging.Debugf("Verbose: stale jar detected mod=%s raw=%s matched=%s\n", modName, filename, jar)
 				break
 			}
 		}

--- a/internal/updater/updater_helpers_test.go
+++ b/internal/updater/updater_helpers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 )
 
@@ -304,6 +305,80 @@ func TestDetectStaleJarsAlreadyScanned(t *testing.T) {
 	result := detectStaleJars(manifestMods, scannedMods, diskJars, db)
 	if len(result) != 0 {
 		t.Errorf("expected no stale jars when mod already scanned, got %+v", result)
+	}
+}
+
+func TestReconcileSanitizedFilenames(t *testing.T) {
+	modsDir := t.TempDir()
+	// Canonical name is clean under the current rule, but an older release wrote
+	// the jar under a legacy-sanitized name (apostrophe dropped, spaces ->'-').
+	const rawJar = "Carpenter's Blocks v3.3.8.2.jar"
+	want := fileutil.SanitizeFilename(rawJar)
+	var legacyJar string
+	for _, v := range fileutil.FilenameVariants(rawJar) {
+		if v != want {
+			legacyJar = v
+			break
+		}
+	}
+	if legacyJar == "" {
+		t.Fatalf("test precondition: expected a legacy variant different from current sanitized form")
+	}
+	if err := os.WriteFile(filepath.Join(modsDir, legacyJar), []byte("jar"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	mods := map[string]config.InstalledMod{
+		"Carpenters Blocks": {
+			Version:     "3.3.8.2",
+			Filename:    legacyJar, // recorded as the legacy on-disk name
+			RawFilename: rawJar,
+			Side:        "BOTH",
+		},
+	}
+
+	reconcileSanitizedFilenames(mods, modsDir)
+
+	// Disk file renamed to the current sanitized form...
+	if _, err := os.Stat(filepath.Join(modsDir, want)); err != nil {
+		t.Fatalf("expected renamed jar %q on disk: %v", want, err)
+	}
+	if _, err := os.Stat(filepath.Join(modsDir, legacyJar)); !os.IsNotExist(err) {
+		t.Fatalf("legacy jar should have been renamed away, stat err=%v", err)
+	}
+	// ...and the in-memory entry updated to match.
+	if got := mods["Carpenters Blocks"].Filename; got != want {
+		t.Fatalf("Filename=%q, want %q", got, want)
+	}
+}
+
+func TestReconcileSanitizedFilenamesSkipsStaleAndClean(t *testing.T) {
+	modsDir := t.TempDir()
+	const cleanJar = "lwjgl3ify-2.1.5.jar"   // needs no sanitization
+	const staleJar = "buildcraft-CUSTOM.jar" // stale placeholder (Version == "")
+	for _, fn := range []string{cleanJar, staleJar} {
+		if err := os.WriteFile(filepath.Join(modsDir, fn), []byte("jar"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) failed: %v", fn, err)
+		}
+	}
+
+	mods := map[string]config.InstalledMod{
+		"lwjgl3ify": {Version: "2.1.5", Filename: cleanJar, RawFilename: cleanJar, Side: "BOTH"},
+		// Stale entry: Version empty, canonical name differs from on-disk jar.
+		"buildcraft": {Version: "", Filename: staleJar, RawFilename: "buildcraft-7.1.55.jar", Side: "BOTH"},
+	}
+
+	reconcileSanitizedFilenames(mods, modsDir)
+
+	// Both files left untouched: clean needs no rename, stale must not be renamed
+	// onto the canonical name (it is slated for removal/replacement).
+	for _, fn := range []string{cleanJar, staleJar} {
+		if _, err := os.Stat(filepath.Join(modsDir, fn)); err != nil {
+			t.Fatalf("expected %q untouched on disk: %v", fn, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(modsDir, "buildcraft-7.1.55.jar")); !os.IsNotExist(err) {
+		t.Fatalf("stale jar must not be renamed to canonical name, stat err=%v", err)
 	}
 }
 

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/diff"
 	"github.com/caedis/gtnh-daily-updater/internal/downloader"
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/gitconfigs"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/lwjgl3ify"
@@ -166,6 +167,41 @@ func refreshTrackedMods(state *config.LocalState, db *assets.AssetsDB, m *manife
 	state.Mods = scannedMods
 	logging.Debugf("Verbose: scanned installed mods=%d\n", len(scannedMods))
 	return nil
+}
+
+// reconcileSanitizedFilenames renames on-disk jars whose recorded on-disk name
+// no longer matches the current sanitization of their canonical (RawFilename)
+// name, updating the in-memory entry to the new name. Stale entries (Version
+// == "") are skipped — they are placeholders slated for removal/replacement,
+// not for renaming. Renames that would clobber an existing file are skipped.
+func reconcileSanitizedFilenames(mods map[string]config.InstalledMod, modsDir string) {
+	for name, installed := range mods {
+		if installed.RawFilename == "" || installed.Filename == "" || installed.Version == "" {
+			continue
+		}
+		want := fileutil.SanitizeFilename(installed.RawFilename)
+		if isDisabledFilename(installed.Filename) {
+			want += disabledSuffix
+		}
+		if want == installed.Filename {
+			continue
+		}
+		oldPath := filepath.Join(modsDir, installed.Filename)
+		newPath := filepath.Join(modsDir, want)
+		if _, err := os.Stat(oldPath); err != nil {
+			continue // nothing on disk to rename
+		}
+		if _, err := os.Stat(newPath); err == nil {
+			continue // destination exists; don't clobber
+		}
+		if err := os.Rename(oldPath, newPath); err != nil {
+			logging.Debugf("Verbose: filename reconcile failed mod=%s %s->%s: %v\n", name, installed.Filename, want, err)
+			continue
+		}
+		logging.Debugf("Verbose: reconciled filename mod=%s %s->%s\n", name, installed.Filename, want)
+		installed.Filename = want
+		mods[name] = installed
+	}
 }
 
 func resolveConfiguredExtras(ctx context.Context, state *config.LocalState, db *assets.AssetsDB, opts Options) (map[string]diff.ResolvedExtraMod, map[string]resolvedExtra, error) {
@@ -389,16 +425,22 @@ func persistUpdatedState(ctx context.Context, state *config.LocalState, changes 
 			// Capture disabled state before the entry is overwritten below.
 			wasDisabled := isDisabledFilename(state.Mods[c.Name].Filename)
 			filename := ""
+			rawFilename := ""
 			if dl, ok := resolveModDownload(ctx, db, c.Name, c.NewVersion, opts.GithubToken, extraDownloads, latestDownloads); ok {
-				filename = dl.Filename
+				// Record both names: RawFilename is the canonical assets-DB name,
+				// Filename is the sanitized form actually written to disk by the
+				// downloader. They must agree or the next scan re-downloads.
+				rawFilename = dl.Filename
+				filename = fileutil.SanitizeFilename(dl.Filename)
 				if wasDisabled {
 					filename += disabledSuffix
 				}
 			}
 			state.Mods[c.Name] = config.InstalledMod{
-				Version:  c.NewVersion,
-				Filename: filename,
-				Side:     c.Side,
+				Version:     c.NewVersion,
+				Filename:    filename,
+				RawFilename: rawFilename,
+				Side:        c.Side,
 			}
 		case diff.Removed:
 			delete(state.Mods, c.Name)


### PR DESCRIPTION
## Problem

Mods whose canonical filename contains characters stripped by `SanitizeFilename` (spaces, `[]`, `()`, `'`) were written to disk under a sanitized name, but the scan filename index, persisted `state.Mods[].Filename`, and stale-jar matcher all keyed on the **raw** name. The on-disk file never matched, so every run re-downloaded the mod and orphaned the old jar.

Confirmed on a real instance: `BiblioCraft[v1.11.7][MC1.7.10].jar` -> `BiblioCraftv1.11.7MC1.7.10.jar`. 5 mods re-downloaded every run before the fix, 0 after.

## Fix

- Record both names per mod: `InstalledMod.RawFilename` (canonical) and `Filename` (actual on-disk).
- Key the filename index on every variant via `fileutil.FilenameVariants` (raw, current sanitized, legacy sanitized) so a jar written by any past rule still resolves.
- `reconcileSanitizedFilenames` renames a drifted jar in place on a real run; skipped under `--dry-run` (no filesystem side effects).

## Loosen sanitization

With the map bridging old/new names, `SanitizeFilename` now allows the actually-valid cross-OS set:
- keeps `[] () '`, spaces, `+ - . _`
- decodes `%XX` (e.g. `%2B` -> `+`)
- replaces only `< > : " / \ | ? *` and control chars with `_`
- strips trailing dots/spaces, guards Windows reserved device names (CON/NUL/COM1-9/...)

## Tests

- `fileutil/sanitize_test.go` — full rule table + `FilenameVariants`
- `TestRun_SanitizedFilenameNotRedownloaded` — legacy-named jar recognized as unchanged
- `TestRun_LegacyNamedJarMigratedNoDuplicate` — real update migrates in place, exactly one jar left
- `TestReconcileSanitizedFilenames` (+ skip stale/clean), updated assets/maven tests
- `go build`, `go vet`, `go test ./...` all pass

Closes #49
Refs #43