### PR TITLE
fix(gitconfigs): force-fetch mutable upstream tags

### DIFF
--- a/internal/gitconfigs/gitconfigs.go
+++ b/internal/gitconfigs/gitconfigs.go
@@ -165,8 +165,10 @@ func ApplyUpdate(ctx context.Context, gameDir, side, prevConfigVersion, newConfi
 		}
 	}
 
-	// Fetch the new tag
-	if err := runGit(ctx, repoDir, "fetch", "--no-tags", "origin", "tag", newConfigVersion); err != nil {
+	// Fetch the new tag. --force so an upstream re-tag (GTNH nightly tags are
+	// mutable) overwrites the local ref instead of silently staying stale, which
+	// would make the merge a no-op and skip the real pack changes.
+	if err := runGit(ctx, repoDir, "fetch", "--force", "--no-tags", "origin", "tag", newConfigVersion); err != nil {
 		return fmt.Errorf("fetching tag %s: %w", newConfigVersion, err)
 	}
 
@@ -259,7 +261,7 @@ func ensureBaseRecorded(ctx context.Context, repoDir, prevConfigVersion string) 
 
 	// Make the previous tag's commit available locally (older runs may have GC'd it).
 	if _, err := runGitOutput(ctx, repoDir, "rev-parse", "-q", "--verify", commitish); err != nil {
-		if ferr := runGit(ctx, repoDir, "fetch", "--no-tags", "origin", "tag", prevConfigVersion); ferr != nil {
+		if ferr := runGit(ctx, repoDir, "fetch", "--force", "--no-tags", "origin", "tag", prevConfigVersion); ferr != nil {
 			logging.Debugf("Verbose: gitconfigs re-baseline skipped, cannot fetch %s: %v\n", prevConfigVersion, ferr)
 			return
 		}

--- a/internal/gitconfigs/gitconfigs_test.go
+++ b/internal/gitconfigs/gitconfigs_test.go
@@ -613,3 +613,83 @@ func TestEnsureGitignoreUntracksCommittedLog(t *testing.T) {
 		t.Fatalf("journeymap.log still tracked: %q", out)
 	}
 }
+
+// TestFetchForceUpdatesMovedUpstreamTag guards the nightly-tag mutation case:
+// GTNH re-points nightly tags upstream; without --force, `git fetch` keeps the
+// stale local ref, the next merge says "Already up to date", and the real pack
+// changes are silently skipped. This reproduces an upstream re-tag and asserts
+// the fetch line ApplyUpdate uses moves the local tag to the new commit.
+func TestFetchForceUpdatesMovedUpstreamTag(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+
+	// Upstream: commit A tagged T, then commit B (T not yet moved).
+	upstream := t.TempDir()
+	gitInit(t, upstream)
+	writeFile(t, filepath.Join(upstream, "f"), "A\n")
+	if err := runGit(ctx, upstream, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, upstream, "commit", "-m", "A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, upstream, "tag", "T"); err != nil {
+		t.Fatal(err)
+	}
+	commitA, err := runGitOutput(ctx, upstream, "rev-parse", "T^{commit}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(upstream, "f"), "B\n")
+	if err := runGit(ctx, upstream, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, upstream, "commit", "-m", "B"); err != nil {
+		t.Fatal(err)
+	}
+	commitB, err := runGitOutput(ctx, upstream, "rev-parse", "HEAD"); if err != nil {
+		t.Fatal(err)
+	}
+
+	// Local clones upstream, pinning tag T at commit A.
+	local := t.TempDir()
+	if err := runGit(ctx, local, "clone", upstream, "."); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	if err := runGit(ctx, local, "config", "user.name", "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, local, "config", "user.email", "test@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, local, "config", "commit.gpgsign", "false"); err != nil {
+		t.Fatal(err)
+	}
+	localT, err := runGitOutput(ctx, local, "rev-parse", "T^{commit}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(localT) != strings.TrimSpace(commitA) {
+		t.Fatalf("setup: local T = %s, want A %s", strings.TrimSpace(localT), strings.TrimSpace(commitA))
+	}
+
+	// Upstream re-points T to commit B (mutable nightly tag).
+	if err := runGit(ctx, upstream, "tag", "-f", "T", strings.TrimSpace(commitB)); err != nil {
+		t.Fatalf("retag upstream: %v", err)
+	}
+
+	// Run the exact fetch line ApplyUpdate uses. Must update local T to B.
+	if err := runGit(ctx, local, "fetch", "--force", "--no-tags", "origin", "tag", "T"); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+
+	got, err := runGitOutput(ctx, local, "rev-parse", "T^{commit}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(got) != strings.TrimSpace(commitB) {
+		t.Fatalf("after force-fetch: local T = %s, want B %s (stale tag, real pack changes would be skipped)", strings.TrimSpace(got), strings.TrimSpace(commitB))
+	}
+}


### PR DESCRIPTION
Without --force, git fetch refuses non-FF tag updates, leaving the local tag stale when GTNH re-points a nightly tag. The next merge then says "Already up to date" and the version-bump commit lands empty, silently skipping the real pack changes until a fresh tag name comes along.