### PR TITLE
feat(updater): prefer GitHub over Maven for latest releases

### DIFF
--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
+	"github.com/caedis/gtnh-daily-updater/internal/github"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
+	"github.com/caedis/gtnh-daily-updater/internal/maven"
 )
 
 // TestRun_SanitizedFilenameNotRedownloaded reproduces issue #49: a mod whose
@@ -1032,4 +1034,394 @@ func (t *updaterRewriteHostTransport) RoundTrip(req *http.Request) (*http.Respon
 	cloned.URL.Scheme = "http"
 	cloned.URL.Host = t.host
 	return t.rt.RoundTrip(cloned)
+}
+
+// rewriteAllHTTPClients points the default client AND the github/maven
+// package-level clients at the test server, so FetchLatestRelease and Maven
+// metadata lookups (which capture their own client at init) are also rewritten.
+func rewriteAllHTTPClients(t *testing.T, server *httptest.Server) func() {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("url.Parse failed: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: &updaterRewriteHostTransport{
+			host: parsed.Host,
+			rt:   server.Client().Transport,
+		},
+	}
+
+	oldDefault := http.DefaultClient
+	http.DefaultClient = client
+	oldGitHub := github.SetHTTPClient(client)
+	oldMaven := maven.HTTPClient
+	maven.HTTPClient = client
+
+	return func() {
+		http.DefaultClient = oldDefault
+		github.SetHTTPClient(oldGitHub)
+		maven.HTTPClient = oldMaven
+	}
+}
+
+func TestResolveLatest_GitHubPreferredOverMavenNoToken(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	state := &config.LocalState{
+		Side:          "client",
+		ManifestDate:  "2026-02-19",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	var githubReleasesHits, mavenMetadataHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version":       "daily",
+				"last_version":  "daily-previous",
+				"last_updated":  "2026-02-20",
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{
+					map[string]any{
+						"name":           "TestMod",
+						"latest_version": "1.0.0",
+						"source":         "",
+						"side":           "BOTH",
+						"versions": []any{
+							map[string]any{
+								"version_tag":          "1.0.0",
+								"filename":             "TestMod-1.0.0.jar",
+								"download_url":         "https://api.github.com/repos/GTNewHorizons/TestMod/releases/assets/1",
+								"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar",
+								"prerelease":           false,
+							},
+						},
+					},
+				},
+			})
+		case "/repos/GTNewHorizons/TestMod/releases":
+			githubReleasesHits++
+			writeJSON(t, w, []any{
+				map[string]any{
+					"tag_name":   "1.2.0",
+					"prerelease": false,
+					"assets": []any{
+						map[string]any{
+							"name":                 "TestMod-1.2.0.jar",
+							"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.2.0/TestMod-1.2.0.jar",
+							"url":                  "https://api.github.com/repos/GTNewHorizons/TestMod/releases/assets/2",
+						},
+					},
+				},
+			})
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/maven-metadata.xml":
+			mavenMetadataHits++
+			w.Header().Set("Content-Type", "application/xml")
+			if _, err := w.Write([]byte(`<metadata><versioning><release>1.1.0</release><versions><version>1.0.0</version><version>1.1.0</version></versions></versioning></metadata>`)); err != nil {
+				t.Fatalf("write maven metadata: %v", err)
+			}
+		case "/GTNewHorizons/TestMod/releases/download/1.2.0/TestMod-1.2.0.jar":
+			if _, err := w.Write([]byte("from-github-1.2.0")); err != nil {
+				t.Fatalf("write jar: %v", err)
+			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.2.0/TestMod-1.2.0.jar.sha256",
+			"/repository/releases/com/github/GTNewHorizons/TestMod/1.2.0/TestMod-1.2.0.jar":
+			// withMavenFallback probes Maven for a fallback hash/URL on the
+			// GitHub-chosen version; the GitHub download succeeds so this is unused.
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
+			writeJSON(t, w, []any{})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restore := rewriteAllHTTPClients(t, server)
+	defer restore()
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		Latest:      true,
+		Concurrency: 2,
+		NoCache:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Added != 1 {
+		t.Fatalf("unexpected summary: %+v", result)
+	}
+	if githubReleasesHits == 0 {
+		t.Fatalf("expected GitHub releases to be queried")
+	}
+	if mavenMetadataHits != 0 {
+		t.Fatalf("Maven metadata must NOT be consulted when GitHub is reachable; hits=%d", mavenMetadataHits)
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-1.2.0.jar")); err != nil {
+		t.Fatalf("expected GitHub version 1.2.0 jar on disk: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(instanceDir, "mods", "TestMod-1.2.0.jar"))
+	if string(data) != "from-github-1.2.0" {
+		t.Fatalf("unexpected jar contents: %q", string(data))
+	}
+}
+
+func TestResolveLatest_AuthFailsFallsBackToAnon(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	state := &config.LocalState{
+		Side: "client", ManifestDate: "2026-02-19", ConfigVersion: "cfg-1",
+		Mods: map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	var authedAttempts, anonAttempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
+				"config":      "cfg-1",
+				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{map[string]any{
+					"name": "TestMod", "latest_version": "1.0.0", "source": "", "side": "BOTH",
+					"versions": []any{map[string]any{
+						"version_tag": "1.0.0", "filename": "TestMod-1.0.0.jar",
+						"download_url":         "https://api.github.com/repos/GTNewHorizons/TestMod/releases/assets/1",
+						"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar",
+						"prerelease":           false,
+					}},
+				}},
+			})
+		case "/repos/GTNewHorizons/TestMod/releases":
+			if r.Header.Get("Authorization") != "" {
+				authedAttempts++
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			anonAttempts++
+			writeJSON(t, w, []any{map[string]any{
+				"tag_name": "1.2.0", "prerelease": false,
+				"assets": []any{map[string]any{
+					"name":                 "TestMod-1.2.0.jar",
+					"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.2.0/TestMod-1.2.0.jar",
+				}},
+			}})
+		case "/GTNewHorizons/TestMod/releases/download/1.2.0/TestMod-1.2.0.jar":
+			if _, err := w.Write([]byte("anon-jar")); err != nil {
+				t.Fatalf("write jar: %v", err)
+			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.2.0/TestMod-1.2.0.jar.sha256",
+			"/repository/releases/com/github/GTNewHorizons/TestMod/1.2.0/TestMod-1.2.0.jar":
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
+			writeJSON(t, w, []any{})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restore := rewriteAllHTTPClients(t, server)
+	defer restore()
+
+	if _, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir, Latest: true, Concurrency: 2, NoCache: true,
+		GithubToken: "test-token",
+	}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if authedAttempts == 0 {
+		t.Fatalf("expected an authenticated attempt first")
+	}
+	if anonAttempts == 0 {
+		t.Fatalf("expected an anonymous retry after auth failure")
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-1.2.0.jar")); err != nil {
+		t.Fatalf("expected 1.2.0 jar from anon retry: %v", err)
+	}
+}
+
+func TestResolveLatest_GitHubUnreachableUsesMaven(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	state := &config.LocalState{
+		Side: "client", ManifestDate: "2026-02-19", ConfigVersion: "cfg-1",
+		Mods: map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	var mavenMetadataHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
+				"config":      "cfg-1",
+				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{map[string]any{
+					"name": "TestMod", "latest_version": "1.0.0", "source": "", "side": "BOTH",
+					"versions": []any{map[string]any{
+						"version_tag": "1.0.0", "filename": "TestMod-1.0.0.jar",
+						"download_url":         "https://api.github.com/repos/GTNewHorizons/TestMod/releases/assets/1",
+						"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar",
+						"prerelease":           false,
+					}},
+				}},
+			})
+		case "/repos/GTNewHorizons/TestMod/releases":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/maven-metadata.xml":
+			mavenMetadataHits++
+			w.Header().Set("Content-Type", "application/xml")
+			if _, err := w.Write([]byte(`<metadata><versioning><release>1.1.0</release><versions><version>1.0.0</version><version>1.1.0</version></versions></versioning></metadata>`)); err != nil {
+				t.Fatalf("write maven metadata: %v", err)
+			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.1.0/TestMod-1.1.0.jar":
+			if _, err := w.Write([]byte("from-maven-1.1.0")); err != nil {
+				t.Fatalf("write jar: %v", err)
+			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.1.0/TestMod-1.1.0.jar.sha256":
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restore := rewriteAllHTTPClients(t, server)
+	defer restore()
+
+	if _, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir, Latest: true, Concurrency: 2, NoCache: true,
+	}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if mavenMetadataHits == 0 {
+		t.Fatalf("expected Maven fallback when GitHub is unreachable")
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-1.1.0.jar")); err != nil {
+		t.Fatalf("expected Maven version 1.1.0 jar on disk: %v", err)
+	}
+}
+
+func TestResolveLatest_GitHubOlderDoesNotConsultMaven(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	state := &config.LocalState{
+		Side: "client", ManifestDate: "2026-02-19", ConfigVersion: "cfg-1",
+		Mods: map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	var mavenMetadataHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
+				"config":      "cfg-1",
+				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{map[string]any{
+					"name": "TestMod", "latest_version": "1.0.0", "source": "", "side": "BOTH",
+					"versions": []any{map[string]any{
+						"version_tag": "1.0.0", "filename": "TestMod-1.0.0.jar",
+						"download_url":         "https://api.github.com/repos/GTNewHorizons/TestMod/releases/assets/1",
+						"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar",
+						"prerelease":           false,
+					}},
+				}},
+			})
+		case "/repos/GTNewHorizons/TestMod/releases":
+			writeJSON(t, w, []any{map[string]any{
+				"tag_name": "1.0.0", "prerelease": false,
+				"assets": []any{map[string]any{
+					"name":                 "TestMod-1.0.0.jar",
+					"browser_download_url": "https://github.com/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar",
+				}},
+			}})
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/maven-metadata.xml":
+			mavenMetadataHits++
+			w.Header().Set("Content-Type", "application/xml")
+			if _, err := w.Write([]byte(`<metadata><versioning><release>1.1.0</release><versions><version>1.0.0</version><version>1.1.0</version></versions></versioning></metadata>`)); err != nil {
+				t.Fatalf("write maven metadata: %v", err)
+			}
+		case "/GTNewHorizons/TestMod/releases/download/1.0.0/TestMod-1.0.0.jar":
+			if _, err := w.Write([]byte("from-github-1.0.0")); err != nil {
+				t.Fatalf("write jar: %v", err)
+			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.0.0/TestMod-1.0.0.jar.sha256",
+			"/repository/releases/com/github/GTNewHorizons/TestMod/1.0.0/TestMod-1.0.0.jar":
+			w.WriteHeader(http.StatusNotFound)
+		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
+			writeJSON(t, w, []any{})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restore := rewriteAllHTTPClients(t, server)
+	defer restore()
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir, Latest: true, Concurrency: 2, NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Updated != 0 {
+		t.Fatalf("expected no update when GitHub latest == current; got %+v", result)
+	}
+	if mavenMetadataHits != 0 {
+		t.Fatalf("Maven must NOT be consulted when GitHub is reachable; hits=%d", mavenMetadataHits)
+	}
+	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-1.0.0.jar")); err != nil {
+		t.Fatalf("expected 1.0.0 jar (added at manifest version): %v", err)
+	}
 }

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -146,20 +146,22 @@ func resolveLatestVersions(ctx context.Context, db *assets.AssetsDB, changes []d
 		}
 	}
 
-	// Pass 2: check Maven metadata for GTNH-hosted mods to catch versions
-	// not yet in the assets DB.
-	logging.Infoln("Checking Maven for latest versions...")
+	// Pass 2: for each GTNH-hosted mod resolve the latest release preferring
+	// GitHub (token if available, anonymous fallback) and dropping to Nexus/Maven
+	// only when GitHub is unreachable. A reachable GitHub response is authoritative.
+	logging.Infoln("Checking GitHub and Maven for latest versions...")
 
-	type mavenResult struct {
+	type latestResult struct {
 		idx     int
 		version string
+		extra   *resolvedExtra // non-nil when resolved from GitHub
 	}
 
 	var (
-		mavenMu      sync.Mutex
-		mavenResults []mavenResult
-		mavenWG      sync.WaitGroup
-		mavenSem     = make(chan struct{}, opts.Concurrency)
+		mu      sync.Mutex
+		results []latestResult
+		wg      sync.WaitGroup
+		sem     = make(chan struct{}, opts.Concurrency)
 	)
 
 	for i, c := range changes {
@@ -173,107 +175,61 @@ func resolveLatestVersions(ctx context.Context, db *assets.AssetsDB, changes []d
 			continue
 		}
 
-		mavenWG.Add(1)
-		go func(idx int, modName, currentVer string) {
-			defer mavenWG.Done()
-			mavenSem <- struct{}{}
-			defer func() { <-mavenSem }()
+		wg.Add(1)
+		go func(idx int, name, currentVer string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 
-			var latestVer string
+			if repo := db.GitHubRepo(name); repo != "" {
+				if gh := fetchLatestReleasePreferToken(ctx, repo, opts.GithubToken, opts.AllowPreRelease); gh != nil {
+					// GitHub reachable: authoritative. Override only when newer.
+					if semver.Compare(gh.Version, currentVer) > 0 {
+						extra := resolvedExtra{
+							URL:         gh.URL,
+							Filename:    gh.Filename,
+							IsGitHubAPI: gh.IsAPI,
+						}
+						if d := strings.TrimPrefix(gh.Digest, "sha256:"); d != "" && d != gh.Digest {
+							extra.ExpectedHash = d
+							extra.HashAlgo = "sha256"
+						}
+						mu.Lock()
+						results = append(results, latestResult{idx: idx, version: gh.Version, extra: &extra})
+						mu.Unlock()
+					}
+					return // do not consult Maven
+				}
+			}
+
+			// GitHub unreachable (or no known repo): fall back to Nexus/Maven.
+			var mavenVer string
 			var err error
 			if opts.AllowPreRelease {
-				latestVer, err = maven.LatestAnyVersion(ctx, modName)
+				mavenVer, err = maven.LatestAnyVersion(ctx, name)
 			} else {
-				latestVer, err = maven.LatestNonPreVersion(ctx, modName)
+				mavenVer, err = maven.LatestNonPreVersion(ctx, name)
 			}
 			if err != nil {
 				return
 			}
-			if semver.Compare(latestVer, currentVer) > 0 {
-				mavenMu.Lock()
-				mavenResults = append(mavenResults, mavenResult{idx: idx, version: latestVer})
-				mavenMu.Unlock()
+			if semver.Compare(mavenVer, currentVer) > 0 {
+				mu.Lock()
+				results = append(results, latestResult{idx: idx, version: mavenVer})
+				mu.Unlock()
 			}
 		}(i, c.Name, c.NewVersion)
 	}
-	mavenWG.Wait()
+	wg.Wait()
 
-	for _, r := range mavenResults {
-		logging.Debugf("Verbose: maven latest override %s %s -> %s\n", changes[r.idx].Name, changes[r.idx].NewVersion, r.version)
+	for _, r := range results {
+		logging.Debugf("Verbose: latest override %s %s -> %s (github=%t)\n", changes[r.idx].Name, changes[r.idx].NewVersion, r.version, r.extra != nil)
 		changes[r.idx].NewVersion = r.version
 		if changes[r.idx].Type == diff.Unchanged {
 			changes[r.idx].Type = diff.Updated
 		}
-	}
-
-	// Pass 3: check GitHub releases for GTNH mods only. Only runs when a token is provided.
-	if opts.GithubToken != "" {
-		logging.Infoln("Checking GitHub for latest releases...")
-
-		type ghResult struct {
-			idx    int
-			result *github.LatestResult
-		}
-
-		var (
-			mu      sync.Mutex
-			results []ghResult
-			wg      sync.WaitGroup
-			sem     = make(chan struct{}, opts.Concurrency)
-		)
-
-		for i, c := range changes {
-			if c.Type == diff.Removed {
-				continue
-			}
-			if _, isExtra := extraDownloads[c.Name]; isExtra {
-				continue
-			}
-			// Only check GTNH-hosted mods
-			if !db.IsGTNH(c.Name) {
-				continue
-			}
-			repo := db.GitHubRepo(c.Name)
-			if repo == "" {
-				continue
-			}
-
-			wg.Add(1)
-			go func(idx int, name, repo, currentVer string) {
-				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				gh, err := github.FetchLatestRelease(ctx, repo, opts.GithubToken, opts.AllowPreRelease)
-				if err != nil {
-					return
-				}
-				// Only use the GitHub version if it's semantically newer
-				if semver.Compare(gh.Version, currentVer) > 0 {
-					mu.Lock()
-					results = append(results, ghResult{idx: idx, result: gh})
-					mu.Unlock()
-				}
-			}(i, c.Name, repo, c.NewVersion)
-		}
-		wg.Wait()
-
-		for _, r := range results {
-			logging.Debugf("Verbose: github latest override %s %s -> %s (asset=%s)\n", changes[r.idx].Name, changes[r.idx].NewVersion, r.result.Version, r.result.Filename)
-			changes[r.idx].NewVersion = r.result.Version
-			if changes[r.idx].Type == diff.Unchanged {
-				changes[r.idx].Type = diff.Updated
-			}
-			extra := resolvedExtra{
-				URL:         r.result.URL,
-				Filename:    r.result.Filename,
-				IsGitHubAPI: r.result.IsAPI,
-			}
-			if d := strings.TrimPrefix(r.result.Digest, "sha256:"); d != "" && d != r.result.Digest {
-				extra.ExpectedHash = d
-				extra.HashAlgo = "sha256"
-			}
-			latestDownloads[changes[r.idx].Name] = extra
+		if r.extra != nil {
+			latestDownloads[changes[r.idx].Name] = *r.extra
 		}
 	}
 
@@ -285,6 +241,21 @@ func resolveLatestVersions(ctx context.Context, db *assets.AssetsDB, changes []d
 			changes[i].Type = diff.Unchanged
 		}
 	}
+}
+
+// fetchLatestReleasePreferToken resolves a repo's latest GitHub release,
+// preferring an authenticated request when a token is set and retrying once
+// anonymously if the authenticated attempt errors. Returns nil only when GitHub
+// is unreachable after both attempts.
+func fetchLatestReleasePreferToken(ctx context.Context, repo, token string, allowPre bool) *github.LatestResult {
+	gh, err := github.FetchLatestRelease(ctx, repo, token, allowPre)
+	if err != nil && token != "" {
+		gh, err = github.FetchLatestRelease(ctx, repo, "", allowPre)
+	}
+	if err != nil {
+		return nil
+	}
+	return gh
 }
 
 // resolveExtraMod resolves an extra mod spec into version/side info and download details.


### PR DESCRIPTION
Latest-release resolution for GTNH mods now queries GitHub first (authenticated when a token is set, anonymous retry otherwise) and falls back to Nexus/Maven only when GitHub is unreachable. A reachable GitHub response is authoritative, so Maven is not consulted even when GitHub's latest is older. Previously Maven ran first and GitHub was gated behind a token.