### PR TITLE
feat(maven): resolve mod group from nexus search

### DIFF
--- a/internal/maven/maven.go
+++ b/internal/maven/maven.go
@@ -2,20 +2,41 @@ package maven
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/semver"
 )
 
-const BaseURL = "https://nexus.gtnewhorizons.com/repository/releases/com/github/GTNewHorizons/"
+const repoBase = "https://nexus.gtnewhorizons.com/repository/releases/"
+
+const gtnhGroup = "com.github.GTNewHorizons"
+
+// searchBase is the Nexus REST search endpoint; a var so tests can override it.
+var searchBase = "https://nexus.gtnewhorizons.com/service/rest/v1/search"
 
 var HTTPClient = http.DefaultClient
+
+var (
+	groupCacheMu sync.Mutex
+	groupCache   = map[string]string{}
+)
+
+type searchResponse struct {
+	Items []searchItem `json:"items"`
+}
+
+type searchItem struct {
+	Group   string `json:"group"`
+	Version string `json:"version"`
+}
 
 type metadata struct {
 	Versioning struct {
@@ -26,20 +47,102 @@ type metadata struct {
 	} `xml:"versioning"`
 }
 
-func MetadataURL(modName string) string {
-	return BaseURL + path.Join(url.PathEscape(modName), "maven-metadata.xml")
+func groupBaseURL(group string) string {
+	return repoBase + strings.ReplaceAll(group, ".", "/") + "/"
 }
 
-func DownloadURL(modName, version string) (dlURL, filename string) {
+func metadataURL(group, modName string) string {
+	return groupBaseURL(group) + path.Join(url.PathEscape(modName), "maven-metadata.xml")
+}
+
+func downloadURL(group, modName, version string) (dlURL, filename string) {
 	filename = MavenFilename(modName, version)
-	dlURL = BaseURL + url.PathEscape(modName) + "/" + url.PathEscape(version) + "/" + url.PathEscape(filename)
+	dlURL = groupBaseURL(group) + url.PathEscape(modName) + "/" + url.PathEscape(version) + "/" + url.PathEscape(filename)
 	return dlURL, filename
+}
+
+// DownloadURL resolves the mod's group and builds its jar download URL.
+func DownloadURL(ctx context.Context, modName, version string) (dlURL, filename string, err error) {
+	group, err := ResolveGroup(ctx, modName)
+	if err != nil {
+		return "", "", err
+	}
+	dlURL, filename = downloadURL(group, modName, version)
+	return dlURL, filename, nil
+}
+
+// ResolveGroup finds the Maven group for a mod via the Nexus search API,
+// preferring the GTNewHorizons group. Results are cached per mod name.
+func ResolveGroup(ctx context.Context, modName string) (string, error) {
+	groupCacheMu.Lock()
+	if g, ok := groupCache[modName]; ok {
+		groupCacheMu.Unlock()
+		return g, nil
+	}
+	groupCacheMu.Unlock()
+
+	g, err := searchGroup(ctx, modName)
+	if err != nil {
+		return "", err
+	}
+
+	groupCacheMu.Lock()
+	groupCache[modName] = g
+	groupCacheMu.Unlock()
+	return g, nil
+}
+
+func searchGroup(ctx context.Context, modName string) (string, error) {
+	u := searchBase + "?repository=releases&maven.artifactId=" + url.QueryEscape(modName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating Nexus search request: %w", err)
+	}
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("searching Nexus: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("searching Nexus for %s: HTTP %d", modName, resp.StatusCode)
+	}
+	var sr searchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return "", fmt.Errorf("parsing Nexus search: %w", err)
+	}
+	return selectGroup(sr.Items, modName)
+}
+
+// selectGroup prefers the GTNewHorizons group; otherwise returns the group of
+// the newest-version item.
+func selectGroup(items []searchItem, modName string) (string, error) {
+	bestGroup, bestVer := "", ""
+	for _, it := range items {
+		g := strings.TrimSpace(it.Group)
+		if g == "" {
+			continue
+		}
+		if g == gtnhGroup {
+			return gtnhGroup, nil
+		}
+		if bestGroup == "" || semver.Compare(it.Version, bestVer) > 0 {
+			bestGroup, bestVer = g, it.Version
+		}
+	}
+	if bestGroup == "" {
+		return "", fmt.Errorf("no Nexus artifact found for %s", modName)
+	}
+	return bestGroup, nil
 }
 
 // LatestAnyVersion fetches Maven metadata for a mod and returns the latest
 // version including pre-releases.
 func LatestAnyVersion(ctx context.Context, modName string) (string, error) {
-	md, err := fetchMetadata(ctx, MetadataURL(modName))
+	group, err := ResolveGroup(ctx, modName)
+	if err != nil {
+		return "", err
+	}
+	md, err := fetchMetadata(ctx, metadataURL(group, modName))
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +170,11 @@ func LatestAnyVersion(ctx context.Context, modName string) (string, error) {
 // LatestNonPreVersion fetches Maven metadata for a mod and returns the latest
 // stable (non "-pre") version.
 func LatestNonPreVersion(ctx context.Context, modName string) (string, error) {
-	md, err := fetchMetadata(ctx, MetadataURL(modName))
+	group, err := ResolveGroup(ctx, modName)
+	if err != nil {
+		return "", err
+	}
+	md, err := fetchMetadata(ctx, metadataURL(group, modName))
 	if err != nil {
 		return "", err
 	}

--- a/internal/maven/maven.go
+++ b/internal/maven/maven.go
@@ -99,6 +99,9 @@ func ResetGroupCache() {
 	groupCacheMu.Unlock()
 }
 
+// searchGroup finds a mod's Maven group via the Nexus search API. The Maven
+// fallback now depends on search availability. Only the first result page is
+// read; that is fine since all pages of one artifact share the same group.
 func searchGroup(ctx context.Context, modName string) (string, error) {
 	u := searchBase + "?repository=releases&maven.artifactId=" + url.QueryEscape(modName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)

--- a/internal/maven/maven.go
+++ b/internal/maven/maven.go
@@ -92,6 +92,13 @@ func ResolveGroup(ctx context.Context, modName string) (string, error) {
 	return g, nil
 }
 
+// ResetGroupCache clears the resolved-group cache. For test isolation.
+func ResetGroupCache() {
+	groupCacheMu.Lock()
+	groupCache = map[string]string{}
+	groupCacheMu.Unlock()
+}
+
 func searchGroup(ctx context.Context, modName string) (string, error) {
 	u := searchBase + "?repository=releases&maven.artifactId=" + url.QueryEscape(modName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)

--- a/internal/maven/maven_test.go
+++ b/internal/maven/maven_test.go
@@ -60,17 +60,74 @@ func TestLatestStableVersion(t *testing.T) {
 	}
 }
 
+func TestSelectGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		items   []searchItem
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "single gtnh group",
+			items: []searchItem{{Group: "com.github.GTNewHorizons", Version: "1.0.0"}},
+			want:  "com.github.GTNewHorizons",
+		},
+		{
+			name:  "single non-gtnh group",
+			items: []searchItem{{Group: "tuhljin.automagy", Version: "0.29.7-GTNH"}},
+			want:  "tuhljin.automagy",
+		},
+		{
+			name: "prefers gtnh when multiple groups present",
+			items: []searchItem{
+				{Group: "tuhljin.automagy", Version: "9.9.9"},
+				{Group: "com.github.GTNewHorizons", Version: "0.0.1"},
+			},
+			want: "com.github.GTNewHorizons",
+		},
+		{
+			name: "no gtnh picks newest version group",
+			items: []searchItem{
+				{Group: "old.group", Version: "1.0.0"},
+				{Group: "new.group", Version: "2.0.0"},
+			},
+			want: "new.group",
+		},
+		{
+			name:    "empty items errors",
+			items:   nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectGroup(tt.items, "Mod")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got group=%q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("selectGroup error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("selectGroup=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMetadataURL(t *testing.T) {
-	t.Run("escapes spaces", func(t *testing.T) {
-		got := MetadataURL("My Mod")
-		if !strings.Contains(got, "/My%20Mod/maven-metadata.xml") {
+	t.Run("gtnh group path and escaping", func(t *testing.T) {
+		got := metadataURL("com.github.GTNewHorizons", "My Mod")
+		if !strings.Contains(got, "/com/github/GTNewHorizons/My%20Mod/maven-metadata.xml") {
 			t.Fatalf("unexpected metadata URL: %s", got)
 		}
 	})
-
-	t.Run("escapes slashes", func(t *testing.T) {
-		got := MetadataURL("mod/name")
-		if !strings.Contains(got, "/mod%2Fname/maven-metadata.xml") {
+	t.Run("non-gtnh group path", func(t *testing.T) {
+		got := metadataURL("tuhljin.automagy", "Automagy-GTNH")
+		if !strings.Contains(got, "/tuhljin/automagy/Automagy-GTNH/maven-metadata.xml") {
 			t.Fatalf("unexpected metadata URL: %s", got)
 		}
 	})
@@ -114,14 +171,48 @@ func TestFetchMetadata(t *testing.T) {
 }
 
 func TestDownloadURL(t *testing.T) {
-	// Spaces are legal in filenames on all target platforms and are now
-	// preserved; the URL path components are percent-escaped separately.
-	url, filename := DownloadURL("My Mod", "1.2.3")
+	url, filename := downloadURL("tuhljin.automagy", "My Mod", "1.2.3")
 	if filename != "My Mod-1.2.3.jar" {
 		t.Fatalf("filename=%q want=%q", filename, "My Mod-1.2.3.jar")
 	}
-	if !strings.Contains(url, "/My%20Mod/1.2.3/My%20Mod-1.2.3.jar") {
+	if !strings.Contains(url, "/tuhljin/automagy/My%20Mod/1.2.3/My%20Mod-1.2.3.jar") {
 		t.Fatalf("unexpected url: %s", url)
+	}
+}
+
+func TestResolveGroup(t *testing.T) {
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Query().Get("maven.artifactId") != "Automagy-GTNH" {
+			t.Fatalf("unexpected artifactId: %s", r.URL.RawQuery)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"group":"tuhljin.automagy","version":"0.29.7-GTNH"}]}`))
+	}))
+	defer server.Close()
+
+	oldClient, oldBase := HTTPClient, searchBase
+	HTTPClient = server.Client()
+	searchBase = server.URL
+	groupCacheMu.Lock()
+	groupCache = map[string]string{}
+	groupCacheMu.Unlock()
+	t.Cleanup(func() { HTTPClient, searchBase = oldClient, oldBase })
+
+	got, err := ResolveGroup(context.Background(), "Automagy-GTNH")
+	if err != nil {
+		t.Fatalf("ResolveGroup error: %v", err)
+	}
+	if got != "tuhljin.automagy" {
+		t.Fatalf("group=%q want=tuhljin.automagy", got)
+	}
+	// second call served from cache, no extra HTTP hit
+	if _, err := ResolveGroup(context.Background(), "Automagy-GTNH"); err != nil {
+		t.Fatalf("second ResolveGroup error: %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("server hits=%d want=1 (cache miss)", hits)
 	}
 }
 

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -713,6 +713,113 @@ func TestRun_GitHubDownloadFailureFallsBackToMaven(t *testing.T) {
 	}
 }
 
+func TestRun_NonGTNHGroupResolvesAndDownloads(t *testing.T) {
+	// Automagy is a GTNH-manifest mod published under group tuhljin.automagy,
+	// not com.github.GTNewHorizons. The Maven fallback must resolve that group
+	// from Nexus search and download from the slashed group path.
+	maven.ResetGroupCache()
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	state := &config.LocalState{
+		Side:          "client",
+		ManifestDate:  "2026-02-19",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	var githubAttempts, mavenAttempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
+			writeJSON(t, w, map[string]any{
+				"version":       "daily",
+				"last_version":  "daily-previous",
+				"last_updated":  "2026-02-20",
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"Automagy": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"external_mods": map[string]any{},
+			})
+		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
+			writeJSON(t, w, map[string]any{
+				"config": map[string]any{"versions": []any{}},
+				"mods": []any{
+					map[string]any{
+						"name":           "Automagy",
+						"latest_version": "1.0.0",
+						"source":         "",
+						"side":           "BOTH",
+						"versions": []any{
+							map[string]any{
+								"version_tag":          "1.0.0",
+								"filename":             "Automagy-1.0.0.jar",
+								"download_url":         "https://api.github.com/repos/GTNewHorizons/Automagy/releases/assets/1",
+								"browser_download_url": "https://github.com/GTNewHorizons/Automagy/releases/download/1.0.0/Automagy-1.0.0.jar",
+								"prerelease":           false,
+							},
+						},
+					},
+				},
+			})
+		case "/repos/GTNewHorizons/Automagy/releases/assets/1":
+			githubAttempts++
+			w.WriteHeader(http.StatusForbidden)
+		case "/repository/releases/tuhljin/automagy/Automagy/1.0.0/Automagy-1.0.0.jar":
+			mavenAttempts++
+			if _, err := w.Write([]byte("from-nongtnh-maven")); err != nil {
+				t.Fatalf("writing maven response: %v", err)
+			}
+		case "/repository/releases/tuhljin/automagy/Automagy/1.0.0/Automagy-1.0.0.jar.sha256":
+			w.WriteHeader(http.StatusNotFound)
+		case "/service/rest/v1/search":
+			if got := r.URL.Query().Get("maven.artifactId"); got != "Automagy" {
+				t.Fatalf("unexpected search artifactId: %q", got)
+			}
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "tuhljin.automagy", "version": "0.29.7-GTNH"}},
+			})
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	restoreClient := rewriteAllHTTPClients(t, server)
+	defer restoreClient()
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		GithubToken: "test-token",
+		NoCache:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.Added != 1 || result.Updated != 0 || result.Removed != 0 {
+		t.Fatalf("unexpected summary: %+v", result)
+	}
+	if githubAttempts == 0 {
+		t.Fatalf("expected at least one GitHub attempt")
+	}
+	if mavenAttempts == 0 {
+		t.Fatalf("expected Maven fallback attempt via resolved non-GTNH group path")
+	}
+
+	jarPath := filepath.Join(instanceDir, "mods", "Automagy-1.0.0.jar")
+	data, err := os.ReadFile(jarPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if string(data) != "from-nongtnh-maven" {
+		t.Fatalf("unexpected jar contents: %q", string(data))
+	}
+}
+
 func TestRun_UpdatesDisabledModKeepsDisabledSuffix(t *testing.T) {
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -668,13 +668,20 @@ func TestRun_GitHubDownloadFailureFallsBackToMaven(t *testing.T) {
 			if _, err := w.Write([]byte("from-maven")); err != nil {
 				t.Fatalf("writing maven response: %v", err)
 			}
+		case "/repository/releases/com/github/GTNewHorizons/TestMod/1.0.0/TestMod-1.0.0.jar.sha256":
+			// withMavenFallback probes for a fallback hash; none published here.
+			w.WriteHeader(http.StatusNotFound)
+		case "/service/rest/v1/search":
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "com.github.GTNewHorizons", "version": "1.0.0"}},
+			})
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}
 	}))
 	defer server.Close()
 
-	restoreClient := rewriteDefaultHTTPClient(t, server)
+	restoreClient := rewriteAllHTTPClients(t, server)
 	defer restoreClient()
 
 	result, err := Run(context.Background(), Options{
@@ -1146,6 +1153,10 @@ func TestResolveLatest_GitHubPreferredOverMavenNoToken(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
 			writeJSON(t, w, []any{})
+		case "/service/rest/v1/search":
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "com.github.GTNewHorizons", "version": "1.0.0"}},
+			})
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}
@@ -1241,6 +1252,10 @@ func TestResolveLatest_AuthFailsFallsBackToAnon(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
 			writeJSON(t, w, []any{})
+		case "/service/rest/v1/search":
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "com.github.GTNewHorizons", "version": "1.0.0"}},
+			})
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}
@@ -1319,6 +1334,10 @@ func TestResolveLatest_GitHubUnreachableUsesMaven(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
 			w.WriteHeader(http.StatusInternalServerError)
+		case "/service/rest/v1/search":
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "com.github.GTNewHorizons", "version": "1.0.0"}},
+			})
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}
@@ -1400,6 +1419,10 @@ func TestResolveLatest_GitHubOlderDoesNotConsultMaven(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		case "/repos/GTNewHorizons/GT-New-Horizons-Modpack/releases":
 			writeJSON(t, w, []any{})
+		case "/service/rest/v1/search":
+			writeJSON(t, w, map[string]any{
+				"items": []any{map[string]any{"group": "com.github.GTNewHorizons", "version": "1.0.0"}},
+			})
 		default:
 			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -609,6 +609,7 @@ func TestRun_LatestOutOfAssetsDBIsNotRepeatedlyAdded(t *testing.T) {
 }
 
 func TestRun_GitHubDownloadFailureFallsBackToMaven(t *testing.T) {
+	maven.ResetGroupCache()
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
@@ -1074,6 +1075,7 @@ func rewriteAllHTTPClients(t *testing.T, server *httptest.Server) func() {
 }
 
 func TestResolveLatest_GitHubPreferredOverMavenNoToken(t *testing.T) {
+	maven.ResetGroupCache()
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
@@ -1194,6 +1196,7 @@ func TestResolveLatest_GitHubPreferredOverMavenNoToken(t *testing.T) {
 }
 
 func TestResolveLatest_AuthFailsFallsBackToAnon(t *testing.T) {
+	maven.ResetGroupCache()
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
@@ -1283,6 +1286,7 @@ func TestResolveLatest_AuthFailsFallsBackToAnon(t *testing.T) {
 }
 
 func TestResolveLatest_GitHubUnreachableUsesMaven(t *testing.T) {
+	maven.ResetGroupCache()
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
@@ -1361,6 +1365,7 @@ func TestResolveLatest_GitHubUnreachableUsesMaven(t *testing.T) {
 }
 
 func TestResolveLatest_GitHubOlderDoesNotConsultMaven(t *testing.T) {
+	maven.ResetGroupCache()
 	instanceDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)

--- a/internal/updater/resolve.go
+++ b/internal/updater/resolve.go
@@ -78,7 +78,7 @@ func resolveModDownload(ctx context.Context, db *assets.AssetsDB, modName, versi
 
 	// Maven fallback for GTNH-hosted mods
 	if db.IsGTNH(modName) {
-		if mavenURL, mavenFn := maven.DownloadURL(modName, version); mavenURL != "" && mavenFn != "" {
+		if mavenURL, mavenFn, err := maven.DownloadURL(ctx, modName, version); err == nil && mavenURL != "" && mavenFn != "" {
 			d := downloader.Download{URL: mavenURL, Filename: mavenFn, ModName: modName}
 			if sha, _ := maven.FetchSHA256(ctx, mavenURL); sha != "" {
 				d.ExpectedHash = sha
@@ -95,8 +95,8 @@ func withMavenFallback(ctx context.Context, dl downloader.Download, db *assets.A
 	if !db.IsGTNH(modName) || !isGitHubDownload(dl.URL, dl.IsGitHubAPI) {
 		return dl
 	}
-	mavenURL, _ := maven.DownloadURL(modName, version)
-	if strings.TrimSpace(mavenURL) == "" || mavenURL == dl.URL {
+	mavenURL, _, err := maven.DownloadURL(ctx, modName, version)
+	if err != nil || strings.TrimSpace(mavenURL) == "" || mavenURL == dl.URL {
 		return dl
 	}
 	dl.MavenFallbackURL = mavenURL
@@ -286,7 +286,10 @@ func resolveExtraMod(ctx context.Context, name string, spec config.ExtraModSpec,
 
 		// Try Maven first for GTNH-hosted mods
 		if db.IsGTNH(name) {
-			mavenURL, mavenFn := maven.DownloadURL(name, version)
+			mavenURL, mavenFn, err := maven.DownloadURL(ctx, name, version)
+			if err != nil {
+				return diff.ResolvedExtraMod{}, resolvedExtra{}, err
+			}
 			logging.Debugf("Verbose: extra mod %s using maven download filename=%s\n", name, mavenFn)
 			extra := resolvedExtra{URL: mavenURL, Filename: mavenFn}
 			if sha, _ := maven.FetchSHA256(ctx, mavenURL); sha != "" {


### PR DESCRIPTION
Nexus group is no longer hardcoded to com.github.GTNewHorizons;
some mods (e.g. Automagy-GTNH) live under other groups and 404'd.
Resolves via Nexus search API, preferring GTNewHorizons, else the
group with the newest version. Cached per mod name.