### PR TITLE
feat(updater): stamp pack version into configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Always make a full instance backup before first using this program
 - Supports excluded mods and user-defined extra mods
 - Supports named profiles and multi-profile batch updates (`update-all`)
 - Download caching and configurable concurrency
+- Stamps the installed pack version into config files, server MOTD, and Prism instance name after each update
 - Optional startup self-update check with SHA256-verified `self-update` command
 
 ## Requirements
@@ -248,6 +249,37 @@ gtnh-daily-updater update-all main-client alt-server
 - `config diff` shows your changes relative to the pack version (`git diff <configVersion>..local`)
 - `config diff "GregTech/Pollution.cfg"` shows diff for a specific file (also accepts `config/GregTech/Pollution.cfg`)
 - Config tracking requires git; config updates are skipped gracefully if git is unavailable or the repo hasn't been initialized yet
+
+## Version Stamping
+
+After each update the installed pack version is written into the same files
+DreamAssemblerXXL stamps when it builds a release, so the main menu, the
+dreamcraft and DreamCoreMod configs, the server MOTD and the Prism instance
+name all match what you have installed:
+
+- `config/txloader/load/mainmenu/version.txt`
+- `config/GTNewHorizons/dreamcraft.cfg` (`S:ModPackVersion`)
+- `config/DreamCoreMod.properties` (`displayedModpackVersion`)
+- `server.properties` (`motd`) — only when the MOTD still starts with `GT:New Horizons`
+- `instance.cfg` (`name`) — only when the name still starts with `GTNH`
+
+The stamped string matches DreamAssemblerXXL's, e.g. `2.9.x (Daily 648) - 2026-07-28`.
+Under `--latest` the mods are newer than the counted build, so the count is marked:
+`2.9.x (Daily 648+) - 2026-07-28`.
+
+Missing files are skipped and never created, and a customized MOTD or instance
+name is left alone. `config/DreamCoreMod.properties` is the one file where a
+missing key is added rather than skipped. Pass `--no-version-stamp` (or set
+`no-version-stamp = true` in a profile) to turn it off.
+
+Because stamping runs after the git-backed config snapshot, the stamped lines
+show up as local modifications in `config diff` on the following run.
+
+Stamping is skipped when a config update itself was skipped — that is, when the
+pack version moved forward but the instance has no config tracking repo yet. Run
+`init` (see above) so the instance stops displaying a version it is not on. Note
+that without git installed, configs are not updated but the version is still
+stamped, so the displayed version can run ahead of the configs on disk.
 
 ## Caching and Performance
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -16,14 +16,15 @@ var profileCmd = &cobra.Command{
 
 // Flags for profile create
 var (
-	profInstanceDir *string
-	profSide        *string
-	profMode        *string
-	profConcurrency *int
-	profLatest      *bool
-	profCacheDir    *string
-	profNoCache     *bool
-	profVerbose     *bool
+	profInstanceDir    *string
+	profSide           *string
+	profMode           *string
+	profConcurrency    *int
+	profLatest         *bool
+	profCacheDir       *string
+	profNoCache        *bool
+	profNoVersionStamp *bool
+	profVerbose        *bool
 )
 
 var profileCreateCmd = &cobra.Command{
@@ -53,6 +54,9 @@ var profileCreateCmd = &cobra.Command{
 		}
 		if cmd.Flags().Changed("no-cache") {
 			p.NoCache = profNoCache
+		}
+		if cmd.Flags().Changed("no-version-stamp") {
+			p.NoVersionStamp = profNoVersionStamp
 		}
 		if cmd.Flags().Changed("verbose") {
 			p.Verbose = profVerbose
@@ -130,6 +134,7 @@ func init() {
 	profLatest = profileCreateCmd.Flags().Bool("latest", false, "Use latest non-pre versions")
 	profCacheDir = profileCreateCmd.Flags().String("cache-dir", "", "Cache directory for downloaded mods")
 	profNoCache = profileCreateCmd.Flags().Bool("no-cache", false, "Disable download caching")
+	profNoVersionStamp = profileCreateCmd.Flags().Bool("no-version-stamp", false, "Do not write the pack version into config files, server.properties or instance.cfg")
 	profVerbose = profileCreateCmd.Flags().Bool("verbose", false, "Enable verbose logging")
 
 	profileCmd.AddCommand(profileCreateCmd, profileListCmd, profileShowCmd, profileDeleteCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,9 @@ var rootCmd = &cobra.Command{
 			if p.NoCache != nil && !cmd.Flags().Changed("no-cache") {
 				noCache = *p.NoCache
 			}
+			if p.NoVersionStamp != nil && !cmd.Flags().Changed("no-version-stamp") {
+				noVersionStamp = *p.NoVersionStamp
+			}
 			if p.Verbose != nil && !cmd.Flags().Changed("verbose") {
 				verbose = *p.Verbose
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,12 +9,13 @@ import (
 )
 
 var (
-	dryRun      bool
-	force       bool
-	latest      bool
-	concurrency int
-	cacheDir    string
-	noCache     bool
+	dryRun         bool
+	force          bool
+	latest         bool
+	concurrency    int
+	cacheDir       string
+	noCache        bool
+	noVersionStamp bool
 )
 
 var updateCmdName = "update"
@@ -24,15 +25,16 @@ var updateCmd = &cobra.Command{
 	Short: "Update mods and tracked pack files to the latest manifest build",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := updater.Options{
-			InstanceDir:   instanceDir,
-			DryRun:        dryRun,
-			Force:         force,
-			Latest:        latest,
-			Concurrency:   concurrency,
-			GithubToken:   getGithubToken(),
-			CurseForgeKey: getCurseForgeKey(),
-			CacheDir:      cacheDir,
-			NoCache:       noCache,
+			InstanceDir:    instanceDir,
+			DryRun:         dryRun,
+			Force:          force,
+			Latest:         latest,
+			Concurrency:    concurrency,
+			GithubToken:    getGithubToken(),
+			CurseForgeKey:  getCurseForgeKey(),
+			CacheDir:       cacheDir,
+			NoCache:        noCache,
+			NoVersionStamp: noVersionStamp,
 		}
 
 		result, err := updater.Run(context.Background(), opts)
@@ -41,6 +43,10 @@ var updateCmd = &cobra.Command{
 		}
 
 		if result.UpToDate || dryRun {
+			// The up-to-date path still repairs a stale version stamp.
+			if len(result.StampedFiles) > 0 {
+				logging.Infof("  Version stamped into %d file(s)\n", len(result.StampedFiles))
+			}
 			return nil
 		}
 
@@ -50,6 +56,10 @@ var updateCmd = &cobra.Command{
 
 		if result.ConfigUpdated {
 			logging.Infoln("  Pack configs: updated to new version")
+		}
+
+		if len(result.StampedFiles) > 0 {
+			logging.Infof("  Version stamped into %d file(s)\n", len(result.StampedFiles))
 		}
 
 		if len(result.Skipped) > 0 {
@@ -67,6 +77,7 @@ func init() {
 	updateCmd.Flags().IntVar(&concurrency, "concurrency", 6, "Number of concurrent downloads")
 	updateCmd.Flags().StringVar(&cacheDir, "cache-dir", "", "Directory for caching downloaded mods (default: OS user cache dir + /gtnh-daily-updater/mods/)")
 	updateCmd.Flags().BoolVar(&noCache, "no-cache", false, "Disable download caching")
+	updateCmd.Flags().BoolVar(&noVersionStamp, "no-version-stamp", false, "Do not write the pack version into config files, server.properties or instance.cfg")
 	rootCmd.AddCommand(updateCmd)
 }
 

--- a/cmd/update_all.go
+++ b/cmd/update_all.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	dryRunAll      bool
-	forceAll       bool
-	latestAll      bool
-	concurrencyAll int
-	cacheDirAll    string
-	noCacheAll     bool
+	dryRunAll         bool
+	forceAll          bool
+	latestAll         bool
+	concurrencyAll    int
+	cacheDirAll       string
+	noCacheAll        bool
+	noVersionStampAll bool
 )
 
 var updateAllCmdName = "update-all"
@@ -106,6 +107,11 @@ var updateAllCmd = &cobra.Command{
 			} else if p.NoCache != nil {
 				opts.NoCache = *p.NoCache
 			}
+			if cmd.Flags().Changed("no-version-stamp") {
+				opts.NoVersionStamp = noVersionStampAll
+			} else if p.NoVersionStamp != nil {
+				opts.NoVersionStamp = *p.NoVersionStamp
+			}
 
 			// Per-profile verbose setting; CLI wins.
 			profileVerbose := verbose
@@ -136,6 +142,9 @@ var updateAllCmd = &cobra.Command{
 			if res.ConfigUpdated {
 				logging.Infoln("  Pack configs: updated to new version")
 			}
+			if len(res.StampedFiles) > 0 {
+				logging.Infof("  Version stamped into %d file(s)\n", len(res.StampedFiles))
+			}
 			if len(res.Skipped) > 0 {
 				logging.Infof("  Skipped: %s\n", joinSkipped(res.Skipped))
 			}
@@ -164,5 +173,6 @@ func init() {
 	updateAllCmd.Flags().IntVar(&concurrencyAll, "concurrency", 6, "Number of concurrent downloads")
 	updateAllCmd.Flags().StringVar(&cacheDirAll, "cache-dir", "", "Directory for caching downloaded mods (default: OS user cache dir + /gtnh-daily-updater/mods/)")
 	updateAllCmd.Flags().BoolVar(&noCacheAll, "no-cache", false, "Disable download caching")
+	updateAllCmd.Flags().BoolVar(&noVersionStampAll, "no-version-stamp", false, "Do not write the pack version into config files, server.properties or instance.cfg")
 	rootCmd.AddCommand(updateAllCmd)
 }

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -20,6 +20,10 @@ type AssetsDB struct {
 	Config AssetEntry   `json:"config"`
 	Mods   []AssetEntry `json:"mods"`
 
+	// Dev build counters, used for the displayed pack version.
+	LatestDaily        int `json:"latest_daily"`
+	LatestExperimental int `json:"latest_experimental"`
+
 	// Index built after parsing
 	modIndex           map[string]*AssetEntry
 	versionFilenameIdx map[string]string // "ModName/version" → filename

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
@@ -73,5 +74,25 @@ func TestBuildFilenameIndexCleanNameNoDuplicate(t *testing.T) {
 	}
 	if idx[clean][0].RawFilename != clean {
 		t.Errorf("RawFilename=%q, want %q", idx[clean][0].RawFilename, clean)
+	}
+}
+
+func TestAssetsDBParsesDevCounters(t *testing.T) {
+	raw := `{
+		"latest_experimental": 141,
+		"latest_daily": 648,
+		"config": {"name": "GT-New-Horizons-Modpack", "latest_version": "2.9.0-nightly-2026-07-28", "versions": []},
+		"mods": []
+	}`
+
+	var db AssetsDB
+	if err := json.Unmarshal([]byte(raw), &db); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if db.LatestDaily != 648 {
+		t.Errorf("LatestDaily = %d, want 648", db.LatestDaily)
+	}
+	if db.LatestExperimental != 141 {
+		t.Errorf("LatestExperimental = %d, want 141", db.LatestExperimental)
 	}
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -86,3 +86,26 @@ func CopyDirExcluding(src, dst string, excludeTopLevel ...string) error {
 		return CopyFile(path, target)
 	})
 }
+
+// WriteFileAtomic writes data through a temp file in the same directory, so an
+// interrupted write cannot leave a truncated config behind.
+func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".gtnh-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -1,0 +1,58 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicCreatesAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+
+	if err := WriteFileAtomic(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("content = %q, want %q", got, "first")
+	}
+
+	if err := WriteFileAtomic(path, []byte("second"), 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic replace: %v", err)
+	}
+	got, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("content = %q, want %q", got, "second")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("dir has %d entries, want 1 (temp file left behind)", len(entries))
+	}
+}
+
+func TestWriteFileAtomicAppliesPerm(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.txt")
+	if err := WriteFileAtomic(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Windows only reflects the owner-write bit; check readability of the mode
+	// we asked for rather than an exact match on that platform.
+	if info.Mode().Perm()&0o600 != 0o600 {
+		t.Fatalf("perm = %v, want at least 0600", info.Mode().Perm())
+	}
+}

--- a/internal/gitconfigs/gitconfigs_test.go
+++ b/internal/gitconfigs/gitconfigs_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/versionstamp"
 )
 
 func gitInit(t *testing.T, dir string) {
@@ -691,5 +693,139 @@ func TestFetchForceUpdatesMovedUpstreamTag(t *testing.T) {
 	}
 	if strings.TrimSpace(got) != strings.TrimSpace(commitB) {
 		t.Fatalf("after force-fetch: local T = %s, want B %s (stale tag, real pack changes would be skipped)", strings.TrimSpace(got), strings.TrimSpace(commitB))
+	}
+}
+
+// stampedLine is what versionstamp writes into DreamCoreMod.properties for the
+// version used below. Used by the merge test, which needs the line pre-placed
+// rather than produced by a real Apply call.
+const stampedLine = "displayedModpackVersion=2.9.x (Daily 648) - 2026-07-28\n"
+
+// setupStampRepo builds a gameDir whose .gtnh-configs repo is on a `local`
+// branch holding the pack's default DreamCoreMod.properties.
+func setupStampRepo(t *testing.T) (gameDir, repoDir string) {
+	t.Helper()
+	ctx := context.Background()
+	gameDir = t.TempDir()
+	repoDir = ConfigRepoDir(gameDir)
+
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitInit(t, repoDir)
+
+	writeFile(t, filepath.Join(repoDir, "config", "DreamCoreMod.properties"), "displayedModpackVersion=2.9.0\n")
+	if err := runGit(ctx, repoDir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "commit", "-m", "pack v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "tag", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "checkout", "-b", "local", "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The instance carries the same file, as it would after Init.
+	writeFile(t, filepath.Join(gameDir, "config", "DreamCoreMod.properties"), "displayedModpackVersion=2.9.0\n")
+	return gameDir, repoDir
+}
+
+// TestSnapshotOfStampedConfigDoesNotChurn proves the real stamp+snapshot round
+// trip is idempotent: stamping and snapshotting twice in a row (same version)
+// produces no tree change on the second round.
+func TestSnapshotOfStampedConfigDoesNotChurn(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	gameDir, repoDir := setupStampRepo(t)
+	v := versionstamp.DisplayVersion{Short: "2.9.x (Daily 648)", Long: "2.9.x (Daily 648) - 2026-07-28", Date: "2026-07-28"}
+
+	// Round 1: stamp the instance for real, then snapshot.
+	stamped, err := versionstamp.Apply(gameDir, gameDir, v)
+	if err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	found := false
+	for _, f := range stamped {
+		if f == "config/DreamCoreMod.properties" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("first Apply did not stamp config/DreamCoreMod.properties, stamped = %v", stamped)
+	}
+	if err := Snapshot(ctx, gameDir, "server"); err != nil {
+		t.Fatalf("first snapshot: %v", err)
+	}
+
+	// Round 2: same version. Apply is idempotent, so nothing changes on disk.
+	if _, err := versionstamp.Apply(gameDir, gameDir, v); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if err := Snapshot(ctx, gameDir, "server"); err != nil {
+		t.Fatalf("second snapshot: %v", err)
+	}
+
+	out, err := runGitOutput(ctx, repoDir, "diff", "HEAD~1", "HEAD", "--name-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("second snapshot changed files: %q", strings.TrimSpace(out))
+	}
+}
+
+// TestStampedConfigMergesCleanlyAcrossPackUpdate checks that a stamped line does
+// not conflict when the pack ships a new version of the same file, and that the
+// pack's value wins (leaving the file ready to be restamped).
+func TestStampedConfigMergesCleanlyAcrossPackUpdate(t *testing.T) {
+	if !IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	gameDir, repoDir := setupStampRepo(t)
+	cfg := filepath.Join(repoDir, "config", "DreamCoreMod.properties")
+
+	// Pack v2 ships its own default for the same key.
+	if err := runGit(ctx, repoDir, "checkout", "main"); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, cfg, "displayedModpackVersion=2.9.1\n")
+	if err := runGit(ctx, repoDir, "add", "-A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "commit", "-m", "pack v2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "tag", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGit(ctx, repoDir, "checkout", "local"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The instance's stamp is snapshotted onto `local`.
+	writeFile(t, filepath.Join(gameDir, "config", "DreamCoreMod.properties"), stampedLine)
+	if err := Snapshot(ctx, gameDir, "server"); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	if err := mergePackVersion(ctx, repoDir, "v2", "Update configs to v2"); err != nil {
+		t.Fatalf("merge v2: %v", err)
+	}
+
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "<<<<<<<") {
+		t.Fatalf("merge left conflict markers: %q", got)
+	}
+	if strings.TrimSpace(string(got)) != "displayedModpackVersion=2.9.1" {
+		t.Fatalf("after merge = %q, want the pack default 2.9.1", strings.TrimSpace(string(got)))
 	}
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -15,15 +15,16 @@ import (
 // Profile holds saveable CLI options. All fields are pointers so we can
 // distinguish "not set" from zero values.
 type Profile struct {
-	InstanceDir *string `toml:"instance-dir,omitempty"`
-	Side        *string `toml:"side,omitempty"`
-	Mode        *string `toml:"mode,omitempty"`
-	Concurrency *int    `toml:"concurrency,omitempty"`
-	Latest      *bool   `toml:"latest,omitempty"`
-	CacheDir    *string `toml:"cache-dir,omitempty"`
-	NoCache     *bool   `toml:"no-cache,omitempty"`
-	Verbose     *bool   `toml:"verbose,omitempty"`
-	LogFile     *string `toml:"log-file,omitempty"`
+	InstanceDir    *string `toml:"instance-dir,omitempty"`
+	Side           *string `toml:"side,omitempty"`
+	Mode           *string `toml:"mode,omitempty"`
+	Concurrency    *int    `toml:"concurrency,omitempty"`
+	Latest         *bool   `toml:"latest,omitempty"`
+	CacheDir       *string `toml:"cache-dir,omitempty"`
+	NoCache        *bool   `toml:"no-cache,omitempty"`
+	NoVersionStamp *bool   `toml:"no-version-stamp,omitempty"`
+	Verbose        *bool   `toml:"verbose,omitempty"`
+	LogFile        *string `toml:"log-file,omitempty"`
 }
 
 // Dir returns the profiles directory under the OS-native user config dir.

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -7,14 +7,18 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
 	"github.com/caedis/gtnh-daily-updater/internal/github"
+	"github.com/caedis/gtnh-daily-updater/internal/gitconfigs"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
+	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 	"github.com/caedis/gtnh-daily-updater/internal/maven"
 )
 
@@ -1558,5 +1562,122 @@ func TestResolveLatest_GitHubOlderDoesNotConsultMaven(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(instanceDir, "mods", "TestMod-1.0.0.jar")); err != nil {
 		t.Fatalf("expected 1.0.0 jar (added at manifest version): %v", err)
+	}
+}
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// TestRun_StampsVersionAfterConfigSnapshot pins the ordering invariant: version
+// stamping must run after snapshotAndUpdateConfigsIfNeeded's Snapshot step,
+// because a git merge there would otherwise restore the pack's un-stamped
+// default and wipe an earlier stamp. The config version is left UNCHANGED
+// versus the manifest so only Snapshot runs (no ApplyUpdate, no network),
+// keeping the whole run offline.
+func TestRun_StampsVersionAfterConfigSnapshot(t *testing.T) {
+	if !gitconfigs.IsGitAvailable() {
+		t.Skip("git not available")
+	}
+	instanceDir := t.TempDir()
+	gameDir := instanceDir // direct/server layout
+	if err := os.MkdirAll(filepath.Join(gameDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	const defaultLine = "displayedModpackVersion=2.9.0\n"
+	cfgPath := filepath.Join(gameDir, "config", "DreamCoreMod.properties")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(defaultLine), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	// .gtnh-configs repo on `local`, seeded with the same (unstamped) config the
+	// instance carries, as it would be after Init.
+	repoDir := gitconfigs.ConfigRepoDir(gameDir)
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	gitCmd(t, repoDir, "init", "-b", "main")
+	gitCmd(t, repoDir, "config", "user.name", "test")
+	gitCmd(t, repoDir, "config", "user.email", "test@example.com")
+	gitCmd(t, repoDir, "config", "commit.gpgsign", "false")
+	repoCfg := filepath.Join(repoDir, "config", "DreamCoreMod.properties")
+	if err := os.MkdirAll(filepath.Dir(repoCfg), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(repoCfg, []byte(defaultLine), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	gitCmd(t, repoDir, "add", "-A")
+	gitCmd(t, repoDir, "commit", "-m", "pack v1")
+	gitCmd(t, repoDir, "checkout", "-b", "local")
+
+	state := &config.LocalState{
+		Side:          "server",
+		ManifestDate:  "2026-07-27",
+		ConfigVersion: "cfg-1",
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	m := &manifest.DailyManifest{
+		Version:      "daily",
+		LastUpdated:  "2026-07-28T00:00:00+00:00",
+		Config:       "cfg-1", // unchanged vs state: ApplyUpdate is never invoked
+		GithubMods:   map[string]manifest.ModInfo{},
+		ExternalMods: map[string]manifest.ModInfo{},
+	}
+	db := &assets.AssetsDB{LatestDaily: 648}
+
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		Force:       true,
+		Shared:      &SharedData{Manifest: m, AssetsDB: db, Mode: "daily"},
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if result.ConfigSkipped {
+		t.Fatalf("expected config not skipped, got ConfigSkipped=true")
+	}
+
+	// The instance's own file must carry the stamp.
+	got, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !strings.Contains(string(got), "Daily 648") {
+		t.Fatalf("instance config not stamped: %q", got)
+	}
+
+	// The snapshot commit (made before stamping in Run's call order) must NOT
+	// contain the stamp — proving the stamp landed after the snapshot.
+	repoContent := gitOutput(t, repoDir, "show", "HEAD:config/DreamCoreMod.properties")
+	if strings.Contains(repoContent, "Daily 648") {
+		t.Fatalf("snapshot commit already contains the stamp: stamping ran before the snapshot: %q", repoContent)
+	}
+	if strings.TrimSpace(repoContent) != strings.TrimSpace(defaultLine) {
+		t.Fatalf("snapshot commit content = %q, want unstamped default %q", repoContent, defaultLine)
 	}
 }

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -84,6 +84,7 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 
 	if !opts.Force && !opts.DryRun && result.Added == 0 && result.Removed == 0 && result.Updated == 0 && state.ConfigVersion == effectiveConfigVersion {
 		result.UpToDate = true
+		stampVersionIfNeeded(opts.InstanceDir, gameDir, m, db, mode, effectiveConfigVersion, opts, result)
 		logging.Infoln("Already up to date.")
 		return result, nil
 	}
@@ -121,6 +122,8 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 	if err := snapshotAndUpdateConfigsIfNeeded(ctx, state, gameDir, result, rollback, effectiveConfigVersion); err != nil {
 		return nil, err
 	}
+	// After the config merge, which restores the pack's default version lines.
+	stampVersionIfNeeded(opts.InstanceDir, gameDir, m, db, mode, effectiveConfigVersion, opts, result)
 	if err := persistUpdatedState(ctx, state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion, result); err != nil {
 		return nil, err
 	}

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -24,6 +24,9 @@ type Options struct {
 	CurseForgeKey   string
 	CacheDir        string
 	NoCache         bool
+	// NoVersionStamp disables writing the pack version into config files,
+	// server.properties and instance.cfg.
+	NoVersionStamp bool
 	// Shared optionally supplies pre-fetched manifest and assets DB.
 	// When non-nil, Run skips those network fetches.
 	Shared *SharedData
@@ -38,7 +41,9 @@ type UpdateResult struct {
 	Unchanged     int
 	ConfigUpdated bool
 	ConfigSkipped bool
-	Skipped       []string
+	// StampedFiles lists pack files whose version stamp was rewritten.
+	StampedFiles []string
+	Skipped      []string
 	// UpToDate is set when Run exited early because nothing needed doing.
 	// Callers use it to decide whether to print a summary, instead of
 	// re-deriving the condition from the version fields.

--- a/internal/updater/versionstamp_test.go
+++ b/internal/updater/versionstamp_test.go
@@ -1,0 +1,159 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/assets"
+	"github.com/caedis/gtnh-daily-updater/internal/manifest"
+)
+
+// stampFixture builds a Prism-style layout (gameDir = instanceDir/.minecraft)
+// with one gameDir-level stamp target (config/DreamCoreMod.properties) and one
+// instanceDir-level target (server.properties), so a swapped (instanceDir,
+// gameDir) argument pair would fail these tests.
+func stampFixture(t *testing.T) (instanceDir, gameDir string) {
+	t.Helper()
+	instanceDir = t.TempDir()
+	gameDir = filepath.Join(instanceDir, ".minecraft")
+
+	cfgPath := filepath.Join(gameDir, "config", "DreamCoreMod.properties")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("displayedModpackVersion=2.9.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	propPath := filepath.Join(instanceDir, "server.properties")
+	if err := os.WriteFile(propPath, []byte("motd=GT:New Horizons\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return instanceDir, gameDir
+}
+
+func TestStampVersionIfNeededStampsDailyVersion(t *testing.T) {
+	instanceDir, gameDir := stampFixture(t)
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	result := &UpdateResult{}
+
+	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{}, result)
+
+	if !slices.Contains(result.StampedFiles, "config/DreamCoreMod.properties") {
+		t.Fatalf("StampedFiles = %v, want DreamCoreMod.properties", result.StampedFiles)
+	}
+	if !slices.Contains(result.StampedFiles, "server.properties") {
+		t.Fatalf("StampedFiles = %v, want server.properties", result.StampedFiles)
+	}
+
+	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "displayedModpackVersion=2.9.x (Daily 648) - 2026-07-28\n"
+	if string(got) != want {
+		t.Errorf("properties = %q, want %q", got, want)
+	}
+
+	// instanceDir-level target: catches an (instanceDir, gameDir) argument swap.
+	gotProp, err := os.ReadFile(filepath.Join(instanceDir, "server.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantProp := "motd=GT:New Horizons 2.9.x (Daily 648) - 2026-07-28\n"
+	if string(gotProp) != wantProp {
+		t.Errorf("server.properties = %q, want %q", gotProp, wantProp)
+	}
+}
+
+func TestStampVersionIfNeededSkipsDryRunAndOptOut(t *testing.T) {
+	for _, opts := range []Options{{DryRun: true}, {NoVersionStamp: true}} {
+		instanceDir, gameDir := stampFixture(t)
+		m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+		db := &assets.AssetsDB{LatestDaily: 648}
+		result := &UpdateResult{}
+
+		stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", opts, result)
+
+		if len(result.StampedFiles) != 0 {
+			t.Errorf("opts %+v: StampedFiles = %v, want none", opts, result.StampedFiles)
+		}
+		got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "displayedModpackVersion=2.9.0\n" {
+			t.Errorf("opts %+v: properties = %q, want untouched", opts, got)
+		}
+	}
+}
+
+// TestStampVersionIfNeededSkipsWhenConfigSkipped covers the case where
+// snapshotAndUpdateConfigsIfNeeded left state.ConfigVersion behind (the
+// .gtnh-configs repo is missing): the instance never actually moved to
+// configVersion, so nothing should be stamped.
+func TestStampVersionIfNeededSkipsWhenConfigSkipped(t *testing.T) {
+	instanceDir, gameDir := stampFixture(t)
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	result := &UpdateResult{ConfigSkipped: true}
+
+	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{}, result)
+
+	if len(result.StampedFiles) != 0 {
+		t.Errorf("StampedFiles = %v, want none", result.StampedFiles)
+	}
+	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "displayedModpackVersion=2.9.0\n" {
+		t.Errorf("properties = %q, want untouched", got)
+	}
+	gotProp, err := os.ReadFile(filepath.Join(instanceDir, "server.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotProp) != "motd=GT:New Horizons\n" {
+		t.Errorf("server.properties = %q, want untouched", gotProp)
+	}
+}
+
+func TestStampVersionIfNeededUsesExperimentalCounter(t *testing.T) {
+	instanceDir, gameDir := stampFixture(t)
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648, LatestExperimental: 141}
+	result := &UpdateResult{}
+
+	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeExperimental, "2.9.0-nightly-2026-07-28", Options{}, result)
+
+	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "displayedModpackVersion=2.9.x (Experimental 141) - 2026-07-28\n"
+	if string(got) != want {
+		t.Errorf("properties = %q, want %q", got, want)
+	}
+}
+
+func TestStampVersionIfNeededLatestMarksCountWithPlus(t *testing.T) {
+	instanceDir, gameDir := stampFixture(t)
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	result := &UpdateResult{}
+
+	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0", Options{Latest: true}, result)
+
+	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "displayedModpackVersion=2.9.x (Daily 648+) - 2026-07-28\n"
+	if string(got) != want {
+		t.Errorf("properties = %q, want %q", got, want)
+	}
+}

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -20,6 +20,7 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/lwjgl3ify"
 	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 	"github.com/caedis/gtnh-daily-updater/internal/paths"
+	"github.com/caedis/gtnh-daily-updater/internal/versionstamp"
 )
 
 func normalizeRunOptions(opts Options) Options {
@@ -460,4 +461,34 @@ func persistUpdatedState(ctx context.Context, state *config.LocalState, changes 
 	logging.Debugf("Verbose: saved state with mode=%s manifest-date=%s config=%s\n", state.Mode, state.ManifestDate, state.ConfigVersion)
 
 	return nil
+}
+
+// stampVersionIfNeeded writes the installed pack version into the files DAXXL
+// stamps at assembly time. Purely cosmetic, so failures only warn.
+func stampVersionIfNeeded(instanceDir, gameDir string, m *manifest.DailyManifest, db *assets.AssetsDB, mode, configVersion string, opts Options, result *UpdateResult) {
+	if opts.DryRun || opts.NoVersionStamp {
+		return
+	}
+	// ConfigSkipped means snapshotAndUpdateConfigsIfNeeded left state.ConfigVersion
+	// at its old value (the .gtnh-configs repo is missing), so the instance never
+	// actually moved to configVersion — do not stamp a version it is not on.
+	if result.ConfigSkipped {
+		return
+	}
+
+	count := db.LatestDaily
+	if mode == manifest.ModeExperimental {
+		count = db.LatestExperimental
+	}
+
+	// --latest picks mods past the counted build, marked with a "+" on the count.
+	v := versionstamp.Build(configVersion, mode, count, m.LastUpdated, opts.Latest)
+	stamped, err := versionstamp.Apply(instanceDir, gameDir, v)
+	if err != nil {
+		logging.Infof("  Warning: version stamping failed: %v\n", err)
+	}
+	if len(stamped) > 0 {
+		logging.Debugf("Verbose: version stamped %v as %q\n", stamped, v.Long)
+	}
+	result.StampedFiles = stamped
 }

--- a/internal/versionstamp/lines.go
+++ b/internal/versionstamp/lines.go
@@ -1,0 +1,100 @@
+package versionstamp
+
+import "strings"
+
+// lineFile is a text file split into lines, remembering each line's own
+// terminator so a rewrite leaves everything it does not touch byte-identical
+// even when a file mixes CRLF and bare-LF endings.
+//
+// eols[i] is the terminator that follows lines[i]: "\n", "\r\n", or "" if
+// lines[i] is the last line and the file has no trailing newline.
+type lineFile struct {
+	lines []string
+	eols  []string
+}
+
+func parseLines(content string) lineFile {
+	if content == "" {
+		return lineFile{}
+	}
+	chunks := strings.SplitAfter(content, "\n")
+	// content ending in "\n" produces a trailing empty chunk; drop it.
+	if n := len(chunks); n > 0 && chunks[n-1] == "" {
+		chunks = chunks[:n-1]
+	}
+	f := lineFile{lines: make([]string, len(chunks)), eols: make([]string, len(chunks))}
+	for i, c := range chunks {
+		switch {
+		case strings.HasSuffix(c, "\r\n"):
+			f.lines[i] = c[:len(c)-2]
+			f.eols[i] = "\r\n"
+		case strings.HasSuffix(c, "\n"):
+			f.lines[i] = c[:len(c)-1]
+			f.eols[i] = "\n"
+		default:
+			f.lines[i] = c
+			f.eols[i] = ""
+		}
+	}
+	return f
+}
+
+func (f lineFile) render() string {
+	var b strings.Builder
+	for i, l := range f.lines {
+		b.WriteString(l)
+		b.WriteString(f.eols[i])
+	}
+	return b.String()
+}
+
+// findKey returns the index of the first line starting with key (ignoring
+// leading whitespace) and the value after it. Index is -1 when absent.
+func (f lineFile) findKey(key string) (int, string) {
+	for i, l := range f.lines {
+		t := strings.TrimLeft(l, " \t")
+		if strings.HasPrefix(t, key) {
+			return i, strings.TrimPrefix(t, key)
+		}
+	}
+	return -1, ""
+}
+
+// setKey rewrites line i as key+value, keeping the line's original indent and
+// terminator. i must be a valid index into f.lines (i.e. not the -1 sentinel
+// findKey returns for "not found"); callers are expected to check that first.
+func (f *lineFile) setKey(i int, key, value string) {
+	line := f.lines[i]
+	indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+	f.lines[i] = indent + key + value
+}
+
+// dominantEOL returns the file's most common line terminator, defaulting to
+// "\n" when there is no majority (including empty/single-line files).
+func (f lineFile) dominantEOL() string {
+	crlf, lf := 0, 0
+	for _, e := range f.eols {
+		switch e {
+		case "\r\n":
+			crlf++
+		case "\n":
+			lf++
+		}
+	}
+	if crlf > lf {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// appendLine adds a new line at the end of the file, terminated with a
+// newline in the file's dominant style. If the previous last line had no
+// trailing newline, one is added so the new line starts on its own line.
+func (f *lineFile) appendLine(line string) {
+	eol := f.dominantEOL()
+	if n := len(f.eols); n > 0 && f.eols[n-1] == "" {
+		f.eols[n-1] = eol
+	}
+	f.lines = append(f.lines, line)
+	f.eols = append(f.eols, eol)
+}

--- a/internal/versionstamp/lines_test.go
+++ b/internal/versionstamp/lines_test.go
@@ -1,0 +1,94 @@
+package versionstamp
+
+import "testing"
+
+func TestParseLinesRoundTrip(t *testing.T) {
+	tests := []string{
+		"",
+		"a",
+		"a\n",
+		"a\nb\n",
+		"a\r\nb\r\n",
+		"a\r\nb",
+		"# comment\n\nkey=value\n",
+		"a\r\nb\n",
+		"a\r",
+		"\n",
+	}
+	for _, in := range tests {
+		if got := parseLines(in).render(); got != in {
+			t.Errorf("round trip of %q = %q", in, got)
+		}
+	}
+}
+
+func TestFindKey(t *testing.T) {
+	f := parseLines("# c\nfoo=1\n    S:ModPackVersion=2.9.0\nbar=2\n")
+
+	i, val := f.findKey("foo=")
+	if i != 1 || val != "1" {
+		t.Errorf("findKey(foo=) = (%d, %q), want (1, \"1\")", i, val)
+	}
+
+	i, val = f.findKey("S:ModPackVersion=")
+	if i != 2 || val != "2.9.0" {
+		t.Errorf("findKey(S:ModPackVersion=) = (%d, %q), want (2, \"2.9.0\")", i, val)
+	}
+
+	if i, _ = f.findKey("missing="); i != -1 {
+		t.Errorf("findKey(missing=) = %d, want -1", i)
+	}
+}
+
+func TestSetKeyPreservesIndentAndOtherLines(t *testing.T) {
+	f := parseLines("# c\n    S:ModPackVersion=old\nbar=2\n")
+	i, _ := f.findKey("S:ModPackVersion=")
+	f.setKey(i, "S:ModPackVersion=", "new")
+
+	want := "# c\n    S:ModPackVersion=new\nbar=2\n"
+	if got := f.render(); got != want {
+		t.Errorf("render() = %q, want %q", got, want)
+	}
+}
+
+func TestSetKeyOnCRLFFilePreservesCRLF(t *testing.T) {
+	f := parseLines("motd=old\r\nport=25565\r\n")
+	i, _ := f.findKey("motd=")
+	f.setKey(i, "motd=", "new")
+
+	want := "motd=new\r\nport=25565\r\n"
+	if got := f.render(); got != want {
+		t.Errorf("render() = %q, want %q", got, want)
+	}
+}
+
+func TestSetKeyOnMixedEndingsPreservesEachLine(t *testing.T) {
+	f := parseLines("motd=old\r\nport=25565\n")
+	i, _ := f.findKey("motd=")
+	f.setKey(i, "motd=", "new")
+
+	want := "motd=new\r\nport=25565\n"
+	if got := f.render(); got != want {
+		t.Errorf("render() = %q, want %q", got, want)
+	}
+}
+
+func TestAppendLineMatchesDominantStyle(t *testing.T) {
+	f := parseLines("a\r\nb\r\n")
+	f.appendLine("c")
+
+	want := "a\r\nb\r\nc\r\n"
+	if got := f.render(); got != want {
+		t.Errorf("render() = %q, want %q", got, want)
+	}
+}
+
+func TestAppendLineOnNoTrailingNewlineAddsOne(t *testing.T) {
+	f := parseLines("a")
+	f.appendLine("b")
+
+	want := "a\nb\n"
+	if got := f.render(); got != want {
+		t.Errorf("render() = %q, want %q", got, want)
+	}
+}

--- a/internal/versionstamp/stamp.go
+++ b/internal/versionstamp/stamp.go
@@ -1,0 +1,145 @@
+package versionstamp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
+	"github.com/caedis/gtnh-daily-updater/internal/logging"
+)
+
+const (
+	mainMenuPath   = "config/txloader/load/mainmenu/version.txt"
+	dreamcraftPath = "config/GTNewHorizons/dreamcraft.cfg"
+	coreModPath    = "config/DreamCoreMod.properties"
+	serverPropPath = "server.properties"
+	instanceCfg    = "instance.cfg"
+
+	dreamcraftKey = "S:ModPackVersion="
+	coreModKey    = "displayedModpackVersion="
+	motdKey       = "motd="
+	nameKey       = "name="
+
+	motdPrefix = "GT:New Horizons"
+	namePrefix = "GTNH"
+)
+
+// Apply stamps the display version into the files DAXXL stamps when assembling
+// a release. Missing files, missing keys and user-customized values are left
+// alone, except config/DreamCoreMod.properties where a missing key is appended.
+// The returned slice names the files actually changed.
+func Apply(instanceDir, gameDir string, v DisplayVersion) ([]string, error) {
+	inGame := func(rel string) string { return filepath.Join(gameDir, filepath.FromSlash(rel)) }
+
+	targets := []struct {
+		name string
+		fn   func() (bool, error)
+	}{
+		{mainMenuPath, func() (bool, error) { return stampMainMenu(inGame(mainMenuPath), v) }},
+		{dreamcraftPath, func() (bool, error) {
+			return stampKey(inGame(dreamcraftPath), dreamcraftKey, v.Long, false, nil)
+		}},
+		{coreModPath, func() (bool, error) {
+			return stampKey(inGame(coreModPath), coreModKey, v.Long, true, nil)
+		}},
+		{serverPropPath, func() (bool, error) {
+			return stampKey(filepath.Join(instanceDir, serverPropPath), motdKey, motdPrefix+" "+v.Long, false, prefixGuard(motdPrefix))
+		}},
+		{instanceCfg, func() (bool, error) {
+			return stampKey(filepath.Join(instanceDir, instanceCfg), nameKey, namePrefix+" "+v.Long, false, prefixGuard(namePrefix))
+		}},
+	}
+
+	var stamped []string
+	var errs []error
+	for _, t := range targets {
+		changed, err := t.fn()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if changed {
+			stamped = append(stamped, t.name)
+		}
+	}
+	return stamped, errors.Join(errs...)
+}
+
+// prefixGuard accepts a value only while it still looks like the one the pack
+// ships, so custom MOTDs and instance names survive an update.
+func prefixGuard(prefix string) func(string) bool {
+	return func(current string) bool {
+		return current == prefix || strings.HasPrefix(current, prefix+" ")
+	}
+}
+
+func stampMainMenu(path string, v DisplayVersion) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logging.Debugf("Verbose: versionstamp skipping missing %s\n", path)
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// DAXXL writes this file whole, with no trailing newline.
+	want := "GTNH " + v.Short
+	if v.Date != "" {
+		want += " (" + v.Date + ")"
+	}
+	if string(content) == want {
+		return false, nil
+	}
+	if err := fileutil.WriteFileAtomic(path, []byte(want), fileMode(path)); err != nil {
+		return false, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func stampKey(path, key, value string, appendIfMissing bool, guard func(string) bool) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logging.Debugf("Verbose: versionstamp skipping missing %s\n", path)
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	f := parseLines(string(content))
+	i, current := f.findKey(key)
+	switch {
+	case i < 0 && !appendIfMissing:
+		logging.Debugf("Verbose: versionstamp key %q not found in %s\n", key, path)
+		return false, nil
+	case i < 0:
+		f.appendLine(key + value)
+	default:
+		if guard != nil && !guard(current) {
+			logging.Debugf("Verbose: versionstamp leaving customized %q in %s\n", key, path)
+			return false, nil
+		}
+		f.setKey(i, key, value)
+	}
+
+	updated := f.render()
+	if updated == string(content) {
+		return false, nil
+	}
+	if err := fileutil.WriteFileAtomic(path, []byte(updated), fileMode(path)); err != nil {
+		return false, fmt.Errorf("writing %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// fileMode returns the file's current permissions, or 0644 if unknown.
+func fileMode(path string) os.FileMode {
+	if info, err := os.Stat(path); err == nil {
+		return info.Mode().Perm()
+	}
+	return 0o644
+}

--- a/internal/versionstamp/stamp_test.go
+++ b/internal/versionstamp/stamp_test.go
@@ -1,0 +1,361 @@
+package versionstamp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+var testVersion = DisplayVersion{
+	Short: "2.9.x (Daily 648)",
+	Long:  "2.9.x (Daily 648) - 2026-07-28",
+	Date:  "2026-07-28",
+}
+
+// writeTestFile creates path and its parents with the given content.
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// fullInstance builds a client-style instance (instanceDir + .minecraft gameDir)
+// carrying every target file with pack-default content.
+func fullInstance(t *testing.T) (instanceDir, gameDir string) {
+	t.Helper()
+	instanceDir = t.TempDir()
+	gameDir = filepath.Join(instanceDir, ".minecraft")
+
+	writeTestFile(t, filepath.Join(gameDir, "config", "txloader", "load", "mainmenu", "version.txt"), "GTNH 2.9.0")
+	writeTestFile(t, filepath.Join(gameDir, "config", "GTNewHorizons", "dreamcraft.cfg"),
+		"# header\ngeneral {\n    S:ModPackVersion=2.9.0\n    B:Other=true\n}\n")
+	writeTestFile(t, filepath.Join(gameDir, "config", "DreamCoreMod.properties"),
+		"#Config file for the ASM part of GTNHCoreMod\ndownloadOnlyOnce=true\ndisplayedModpackVersion=2.9.0\n")
+	writeTestFile(t, filepath.Join(instanceDir, "server.properties"),
+		"#Minecraft server properties\nmotd=GT:New Horizons 2.9.0\nserver-port=25565\n")
+	writeTestFile(t, filepath.Join(instanceDir, "instance.cfg"),
+		"InstanceType=OneSix\nname=GTNH 2.9.0\niconKey=gtnh_icon\n")
+	return instanceDir, gameDir
+}
+
+func TestApplyStampsAllTargets(t *testing.T) {
+	instanceDir, gameDir := fullInstance(t)
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	want := []string{
+		"config/txloader/load/mainmenu/version.txt",
+		"config/GTNewHorizons/dreamcraft.cfg",
+		"config/DreamCoreMod.properties",
+		"server.properties",
+		"instance.cfg",
+	}
+	if !slices.Equal(stamped, want) {
+		t.Fatalf("stamped = %v, want %v", stamped, want)
+	}
+
+	if got := readTestFile(t, filepath.Join(gameDir, "config", "txloader", "load", "mainmenu", "version.txt")); got != "GTNH 2.9.x (Daily 648) (2026-07-28)" {
+		t.Errorf("version.txt = %q", got)
+	}
+	if got := readTestFile(t, filepath.Join(gameDir, "config", "GTNewHorizons", "dreamcraft.cfg")); got != "# header\ngeneral {\n    S:ModPackVersion=2.9.x (Daily 648) - 2026-07-28\n    B:Other=true\n}\n" {
+		t.Errorf("dreamcraft.cfg = %q", got)
+	}
+	if got := readTestFile(t, filepath.Join(gameDir, "config", "DreamCoreMod.properties")); got != "#Config file for the ASM part of GTNHCoreMod\ndownloadOnlyOnce=true\ndisplayedModpackVersion=2.9.x (Daily 648) - 2026-07-28\n" {
+		t.Errorf("DreamCoreMod.properties = %q", got)
+	}
+	if got := readTestFile(t, filepath.Join(instanceDir, "server.properties")); got != "#Minecraft server properties\nmotd=GT:New Horizons 2.9.x (Daily 648) - 2026-07-28\nserver-port=25565\n" {
+		t.Errorf("server.properties = %q", got)
+	}
+	if got := readTestFile(t, filepath.Join(instanceDir, "instance.cfg")); got != "InstanceType=OneSix\nname=GTNH 2.9.x (Daily 648) - 2026-07-28\niconKey=gtnh_icon\n" {
+		t.Errorf("instance.cfg = %q", got)
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	instanceDir, gameDir := fullInstance(t)
+
+	versionTxt := filepath.Join(gameDir, "config", "txloader", "load", "mainmenu", "version.txt")
+	coreMod := filepath.Join(gameDir, "config", "DreamCoreMod.properties")
+
+	if _, err := Apply(instanceDir, gameDir, testVersion); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	beforeServerProps := readTestFile(t, filepath.Join(instanceDir, "server.properties"))
+	beforeVersionTxt := readTestFile(t, versionTxt)
+	beforeCoreMod := readTestFile(t, coreMod)
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if len(stamped) != 0 {
+		t.Errorf("second Apply stamped %v, want nothing", stamped)
+	}
+	if after := readTestFile(t, filepath.Join(instanceDir, "server.properties")); after != beforeServerProps {
+		t.Errorf("server.properties changed on second apply: %q -> %q", beforeServerProps, after)
+	}
+	if after := readTestFile(t, versionTxt); after != beforeVersionTxt {
+		t.Errorf("version.txt changed on second apply: %q -> %q", beforeVersionTxt, after)
+	}
+	if after := readTestFile(t, coreMod); after != beforeCoreMod {
+		t.Errorf("DreamCoreMod.properties changed on second apply: %q -> %q", beforeCoreMod, after)
+	}
+}
+
+// TestApplyPreservesFileMode verifies stamping rewrites content without
+// altering the file's existing permission bits.
+func TestApplyPreservesFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits not meaningful on windows")
+	}
+	instanceDir, gameDir := fullInstance(t)
+	path := filepath.Join(instanceDir, "server.properties")
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Apply(instanceDir, gameDir, testVersion); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("server.properties mode = %o, want %o", got, 0o600)
+	}
+}
+
+func TestApplySkipsMissingFiles(t *testing.T) {
+	instanceDir := t.TempDir()
+	gameDir := instanceDir // server layout, no .minecraft
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(stamped) != 0 {
+		t.Errorf("stamped = %v, want nothing", stamped)
+	}
+}
+
+func TestApplySkipsDreamcraftWithoutKey(t *testing.T) {
+	instanceDir := t.TempDir()
+	gameDir := instanceDir
+	path := filepath.Join(gameDir, "config", "GTNewHorizons", "dreamcraft.cfg")
+	writeTestFile(t, path, "general {\n    B:Other=true\n}\n")
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(stamped) != 0 {
+		t.Errorf("stamped = %v, want nothing", stamped)
+	}
+	if got := readTestFile(t, path); got != "general {\n    B:Other=true\n}\n" {
+		t.Errorf("dreamcraft.cfg = %q, want untouched", got)
+	}
+}
+
+func TestApplyAppendsMissingCoreModKey(t *testing.T) {
+	instanceDir := t.TempDir()
+	gameDir := instanceDir
+	path := filepath.Join(gameDir, "config", "DreamCoreMod.properties")
+	writeTestFile(t, path, "downloadOnlyOnce=true\n")
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(stamped, "config/DreamCoreMod.properties") {
+		t.Fatalf("stamped = %v, want DreamCoreMod.properties", stamped)
+	}
+	want := "downloadOnlyOnce=true\ndisplayedModpackVersion=2.9.x (Daily 648) - 2026-07-28\n"
+	if got := readTestFile(t, path); got != want {
+		t.Errorf("DreamCoreMod.properties = %q, want %q", got, want)
+	}
+}
+
+func TestApplyLeavesCustomMotdAndName(t *testing.T) {
+	instanceDir, gameDir := fullInstance(t)
+	custom := "#Minecraft server properties\nmotd=Bob's Server\nserver-port=25565\n"
+	writeTestFile(t, filepath.Join(instanceDir, "server.properties"), custom)
+	customCfg := "InstanceType=OneSix\nname=My Pack\niconKey=gtnh_icon\n"
+	writeTestFile(t, filepath.Join(instanceDir, "instance.cfg"), customCfg)
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if slices.Contains(stamped, "server.properties") || slices.Contains(stamped, "instance.cfg") {
+		t.Fatalf("stamped = %v, want neither server.properties nor instance.cfg", stamped)
+	}
+	if got := readTestFile(t, filepath.Join(instanceDir, "server.properties")); got != custom {
+		t.Errorf("server.properties = %q, want untouched", got)
+	}
+	if got := readTestFile(t, filepath.Join(instanceDir, "instance.cfg")); got != customCfg {
+		t.Errorf("instance.cfg = %q, want untouched", got)
+	}
+}
+
+// TestApplyGuardNearMisses proves prefixGuard is stricter than a plain
+// strings.HasPrefix: values that merely start with the pack prefix but aren't
+// "prefix" or "prefix " must still be treated as customized.
+func TestApplyGuardNearMisses(t *testing.T) {
+	cases := []struct {
+		name  string
+		motd  string
+		iname string
+	}{
+		{"concatenated-suffix", "GT:New Horizonsable", "GTNH-custom"},
+		{"empty-value", "", ""},
+		{"wrong-case", "gt:new horizons 2.9.0", "gtnhable"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			instanceDir, gameDir := fullInstance(t)
+			serverProps := "#Minecraft server properties\nmotd=" + c.motd + "\nserver-port=25565\n"
+			writeTestFile(t, filepath.Join(instanceDir, "server.properties"), serverProps)
+			instanceCfgContent := "InstanceType=OneSix\nname=" + c.iname + "\niconKey=gtnh_icon\n"
+			writeTestFile(t, filepath.Join(instanceDir, "instance.cfg"), instanceCfgContent)
+
+			stamped, err := Apply(instanceDir, gameDir, testVersion)
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if slices.Contains(stamped, "server.properties") || slices.Contains(stamped, "instance.cfg") {
+				t.Fatalf("stamped = %v, want neither server.properties nor instance.cfg", stamped)
+			}
+			if got := readTestFile(t, filepath.Join(instanceDir, "server.properties")); got != serverProps {
+				t.Errorf("server.properties = %q, want untouched", got)
+			}
+			if got := readTestFile(t, filepath.Join(instanceDir, "instance.cfg")); got != instanceCfgContent {
+				t.Errorf("instance.cfg = %q, want untouched", got)
+			}
+		})
+	}
+}
+
+// TestApplyStampsBarePackDefault proves the guard still accepts the exact
+// bare pack default (no trailing version), the "current == prefix" branch.
+func TestApplyStampsBarePackDefault(t *testing.T) {
+	instanceDir, gameDir := fullInstance(t)
+	writeTestFile(t, filepath.Join(instanceDir, "server.properties"),
+		"#Minecraft server properties\nmotd=GT:New Horizons\nserver-port=25565\n")
+	writeTestFile(t, filepath.Join(instanceDir, "instance.cfg"),
+		"InstanceType=OneSix\nname=GTNH\niconKey=gtnh_icon\n")
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(stamped, "server.properties") || !slices.Contains(stamped, "instance.cfg") {
+		t.Fatalf("stamped = %v, want both server.properties and instance.cfg", stamped)
+	}
+	want := "#Minecraft server properties\nmotd=GT:New Horizons " + testVersion.Long + "\nserver-port=25565\n"
+	if got := readTestFile(t, filepath.Join(instanceDir, "server.properties")); got != want {
+		t.Errorf("server.properties = %q, want %q", got, want)
+	}
+	wantCfg := "InstanceType=OneSix\nname=GTNH " + testVersion.Long + "\niconKey=gtnh_icon\n"
+	if got := readTestFile(t, filepath.Join(instanceDir, "instance.cfg")); got != wantCfg {
+		t.Errorf("instance.cfg = %q, want %q", got, wantCfg)
+	}
+}
+
+func TestApplyNonDevVersionOmitsDateFromMainMenu(t *testing.T) {
+	instanceDir, gameDir := fullInstance(t)
+	v := DisplayVersion{Short: "2.9.0", Long: "2.9.0"}
+
+	if _, err := Apply(instanceDir, gameDir, v); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := readTestFile(t, filepath.Join(gameDir, "config", "txloader", "load", "mainmenu", "version.txt")); got != "GTNH 2.9.0" {
+		t.Errorf("version.txt = %q, want %q", got, "GTNH 2.9.0")
+	}
+}
+
+// TestApplyContinuesPastOneTargetFailure verifies that a read error on one
+// target doesn't stop the rest, and that the error surfaces mentioning the
+// failing path.
+func TestApplyContinuesPastOneTargetFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0000 does not block reads")
+	}
+	instanceDir, gameDir := fullInstance(t)
+	dreamcraft := filepath.Join(gameDir, "config", "GTNewHorizons", "dreamcraft.cfg")
+	if err := os.Chmod(dreamcraft, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(dreamcraft, 0o644)
+
+	stamped, err := Apply(instanceDir, gameDir, testVersion)
+	if err == nil {
+		t.Fatal("Apply: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), dreamcraft) {
+		t.Errorf("Apply error = %q, want it to mention %q", err.Error(), dreamcraft)
+	}
+
+	for _, name := range []string{
+		"config/txloader/load/mainmenu/version.txt",
+		"config/DreamCoreMod.properties",
+		"server.properties",
+		"instance.cfg",
+	} {
+		if !slices.Contains(stamped, name) {
+			t.Errorf("stamped = %v, want it to include %q despite the other failure", stamped, name)
+		}
+	}
+}
+
+// TestApplyStripsTrailingNewlineFromMainMenu proves version.txt is rewritten
+// without a trailing newline even when the source file has one.
+func TestApplyStripsTrailingNewlineFromMainMenu(t *testing.T) {
+	instanceDir := t.TempDir()
+	gameDir := instanceDir
+	path := filepath.Join(gameDir, "config", "txloader", "load", "mainmenu", "version.txt")
+	writeTestFile(t, path, "GTNH 2.9.0\n")
+
+	if _, err := Apply(instanceDir, gameDir, testVersion); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	want := "GTNH " + testVersion.Short + " (" + testVersion.Date + ")"
+	if got := readTestFile(t, path); got != want {
+		t.Errorf("version.txt = %q, want %q (no trailing newline)", got, want)
+	}
+}
+
+func TestApplyPreservesCRLFServerProperties(t *testing.T) {
+	instanceDir := t.TempDir()
+	gameDir := instanceDir
+	path := filepath.Join(instanceDir, "server.properties")
+	writeTestFile(t, path, "motd=GT:New Horizons 2.9.0\r\nserver-port=25565\r\n")
+
+	if _, err := Apply(instanceDir, gameDir, testVersion); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	want := "motd=GT:New Horizons 2.9.x (Daily 648) - 2026-07-28\r\nserver-port=25565\r\n"
+	if got := readTestFile(t, path); got != want {
+		t.Errorf("server.properties = %q, want %q", got, want)
+	}
+}

--- a/internal/versionstamp/version.go
+++ b/internal/versionstamp/version.go
@@ -1,0 +1,53 @@
+// Package versionstamp writes the pack's display version into the same files
+// DreamAssemblerXXL stamps when it assembles a release.
+package versionstamp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// DisplayVersion holds the version strings DAXXL stamps into pack files.
+type DisplayVersion struct {
+	Short string // "2.9.x (Daily 648)"
+	Long  string // "2.9.x (Daily 648) - 2026-07-28"
+	Date  string // "2026-07-28", empty when unknown
+}
+
+var cyclePattern = regexp.MustCompile(`^(\d+)\.(\d+)\.`)
+
+// DevCycle turns a config version like "2.9.0-nightly-2026-07-28" into the
+// cycle string DAXXL displays ("2.9.x"). Unparseable input is returned as-is.
+func DevCycle(configVersion string) string {
+	m := cyclePattern.FindStringSubmatch(configVersion)
+	if m == nil {
+		return configVersion
+	}
+	return m[1] + "." + m[2] + ".x"
+}
+
+// Build assembles the display version. beyondCounter marks a --latest run,
+// whose mods are picked past the counted build; its count gets a "+" suffix.
+func Build(configVersion, mode string, count int, lastUpdated string, beyondCounter bool) DisplayVersion {
+	kind := "Daily"
+	if strings.EqualFold(mode, "experimental") {
+		kind = "Experimental"
+	}
+	countStr := strconv.Itoa(count)
+	if beyondCounter {
+		countStr += "+"
+	}
+	short := fmt.Sprintf("%s (%s %s)", DevCycle(configVersion), kind, countStr)
+
+	date := ""
+	if len(lastUpdated) >= 10 {
+		date = lastUpdated[:10]
+	}
+	long := short
+	if date != "" {
+		long = short + " - " + date
+	}
+	return DisplayVersion{Short: short, Long: long, Date: date}
+}

--- a/internal/versionstamp/version_test.go
+++ b/internal/versionstamp/version_test.go
@@ -1,0 +1,117 @@
+package versionstamp
+
+import "testing"
+
+func TestDevCycle(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"2.9.0-nightly-2026-07-28", "2.9.x"},
+		{"2.10.3", "2.10.x"},
+		{"2.9.0", "2.9.x"},
+		{"nightly", "nightly"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := DevCycle(tc.in); got != tc.want {
+			t.Errorf("DevCycle(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		name        string
+		configVer   string
+		mode        string
+		count       int
+		lastUpdated string
+		beyond      bool
+		wantShort   string
+		wantLong    string
+		wantDate    string
+	}{
+		{
+			name:        "daily",
+			configVer:   "2.9.0-nightly-2026-07-28",
+			mode:        "daily",
+			count:       648,
+			lastUpdated: "2026-07-28T13:58:48.371055+00:00",
+			beyond:      false,
+			wantShort:   "2.9.x (Daily 648)",
+			wantLong:    "2.9.x (Daily 648) - 2026-07-28",
+			wantDate:    "2026-07-28",
+		},
+		{
+			name:        "experimental",
+			configVer:   "2.9.0-nightly-2026-07-28",
+			mode:        "experimental",
+			count:       141,
+			lastUpdated: "2026-07-28T13:58:48.371055+00:00",
+			beyond:      false,
+			wantShort:   "2.9.x (Experimental 141)",
+			wantLong:    "2.9.x (Experimental 141) - 2026-07-28",
+			wantDate:    "2026-07-28",
+		},
+		{
+			name:        "latest marks the count with a plus",
+			configVer:   "2.9.0-nightly-2026-07-28",
+			mode:        "daily",
+			count:       648,
+			lastUpdated: "2026-07-28T13:58:48.371055+00:00",
+			beyond:      true,
+			wantShort:   "2.9.x (Daily 648+)",
+			wantLong:    "2.9.x (Daily 648+) - 2026-07-28",
+			wantDate:    "2026-07-28",
+		},
+		{
+			name:        "latest on a release tag keeps the cycle form",
+			configVer:   "2.9.0",
+			mode:        "experimental",
+			count:       141,
+			lastUpdated: "2026-07-28T13:58:48.371055+00:00",
+			beyond:      true,
+			wantShort:   "2.9.x (Experimental 141+)",
+			wantLong:    "2.9.x (Experimental 141+) - 2026-07-28",
+			wantDate:    "2026-07-28",
+		},
+		{
+			name:        "missing date drops the suffix",
+			configVer:   "2.9.0-nightly-2026-07-28",
+			mode:        "daily",
+			count:       648,
+			lastUpdated: "",
+			beyond:      false,
+			wantShort:   "2.9.x (Daily 648)",
+			wantLong:    "2.9.x (Daily 648)",
+			wantDate:    "",
+		},
+		{
+			name:        "unparseable cycle falls back to raw version",
+			configVer:   "weird-tag",
+			mode:        "daily",
+			count:       1,
+			lastUpdated: "2026-07-28",
+			beyond:      false,
+			wantShort:   "weird-tag (Daily 1)",
+			wantLong:    "weird-tag (Daily 1) - 2026-07-28",
+			wantDate:    "2026-07-28",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Build(tc.configVer, tc.mode, tc.count, tc.lastUpdated, tc.beyond)
+			if got.Short != tc.wantShort {
+				t.Errorf("Short = %q, want %q", got.Short, tc.wantShort)
+			}
+			if got.Long != tc.wantLong {
+				t.Errorf("Long = %q, want %q", got.Long, tc.wantLong)
+			}
+			if got.Date != tc.wantDate {
+				t.Errorf("Date = %q, want %q", got.Date, tc.wantDate)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Match DreamAssemblerXXL PR 299: write the installed version into mainmenu version.txt, dreamcraft.cfg, DreamCoreMod.properties, server.properties motd and Prism instance.cfg name. MOTD and instance name are only touched while they still look pack-default. Opt out with `--no-version-stamp`.

Runs after the gitconfigs merge, which would otherwise restore the pack defaults.

<img width="775" height="117" alt="image" src="https://github.com/user-attachments/assets/5d02c055-3e4c-4563-93c3-970da9e580b8" />
