### PR TITLE
feat(updater): report pack version in summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ gtnh-daily-updater update-all main-client alt-server
 ## State, Paths, and Merge Behavior
 
 - Local state is stored at `<instance-dir>/.gtnh-daily-updater.json`
+- That state records `display_version`, the pack version as shown in game, so the next run can report what you upgraded from; instances updated before it existed fall back to the config version once
 - On Prism/MultiMC layouts, game files are resolved under `<instance-dir>/.minecraft/`
 - On server/other layouts, game files are resolved directly under `<instance-dir>/`
 - Config files are tracked in a git repo at `<game-dir>/.gtnh-configs/` on a `local` branch; pack updates are applied via `git merge -X theirs` (pack wins on conflicts)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -22,7 +22,7 @@ var statusCmd = &cobra.Command{
 				instanceDir = *p.InstanceDir
 			}
 		}
-		return updater.Status(context.Background(), instanceDir, getGithubToken())
+		return updater.Status(context.Background(), instanceDir, getGithubToken(), getCurseForgeKey())
 	},
 }
 

--- a/cmd/summary_test.go
+++ b/cmd/summary_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import "testing"
+
+func TestVersionTransition(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{
+			name: "version moved",
+			old:  "2.9.x (Daily 647) - 2026-07-27",
+			new:  "2.9.x (Daily 648) - 2026-07-28",
+			want: "2.9.x (Daily 647) - 2026-07-27 → 2.9.x (Daily 648) - 2026-07-28",
+		},
+		{
+			name: "version held still",
+			old:  "2.9.x (Daily 653+) - 2026-07-30",
+			new:  "2.9.x (Daily 653+) - 2026-07-30",
+			want: "2.9.x (Daily 653+) - 2026-07-30 (pack version unchanged)",
+		},
+		{
+			// Instances updated before display versions were tracked report the
+			// config tag on the left; the two sides differ, so it still reads
+			// as a transition.
+			name: "migration from a config tag",
+			old:  "2.9.0-nightly-2026-07-29-02",
+			new:  "2.9.x (Daily 653) - 2026-07-30",
+			want: "2.9.0-nightly-2026-07-29-02 → 2.9.x (Daily 653) - 2026-07-30",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionTransition(tc.old, tc.new); got != tc.want {
+				t.Errorf("versionTransition(%q, %q) = %q, want %q", tc.old, tc.new, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionCell(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want string
+	}{
+		{
+			name: "version moved",
+			old:  "2.9.x (Daily 647) - 2026-07-27",
+			new:  "2.9.x (Daily 648) - 2026-07-28",
+			want: "2.9.x (Daily 647) - 2026-07-27 → 2.9.x (Daily 648) - 2026-07-28",
+		},
+		{
+			name: "version held still carries no note",
+			old:  "2.9.x (Daily 653+) - 2026-07-30",
+			new:  "2.9.x (Daily 653+) - 2026-07-30",
+			want: "2.9.x (Daily 653+) - 2026-07-30",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionCell(tc.old, tc.new); got != tc.want {
+				t.Errorf("versionCell(%q, %q) = %q, want %q", tc.old, tc.new, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -50,12 +50,12 @@ var updateCmd = &cobra.Command{
 			return nil
 		}
 
-		logging.Infof("\nUpdate complete: %s → %s\n", result.OldVersion, result.NewVersion)
+		logging.Infof("\nUpdate complete: %s\n", versionTransition(result.OldVersion, result.NewVersion))
 		logging.Infof("  Mods: %d added, %d removed, %d updated, %d unchanged\n",
 			result.Added, result.Removed, result.Updated, result.Unchanged)
 
 		if result.ConfigUpdated {
-			logging.Infoln("  Pack configs: updated to new version")
+			logging.Infof("  Pack configs: %s → %s\n", result.OldConfigVersion, result.NewConfigVersion)
 		}
 
 		if len(result.StampedFiles) > 0 {
@@ -79,6 +79,24 @@ func init() {
 	updateCmd.Flags().BoolVar(&noCache, "no-cache", false, "Disable download caching")
 	updateCmd.Flags().BoolVar(&noVersionStamp, "no-version-stamp", false, "Do not write the pack version into config files, server.properties or instance.cfg")
 	rootCmd.AddCommand(updateCmd)
+}
+
+// versionTransition renders the headline form: an arrow when the pack version
+// moved, otherwise the current version with a note.
+func versionTransition(old, new string) string {
+	if old == new {
+		return new + " (pack version unchanged)"
+	}
+	return old + " → " + new
+}
+
+// versionCell renders the table form: an arrow when the pack version moved,
+// otherwise just the version. No prose — it sits in a column.
+func versionCell(old, new string) string {
+	if old == new {
+		return new
+	}
+	return old + " → " + new
 }
 
 func joinSkipped(s []string) string {

--- a/cmd/update_all.go
+++ b/cmd/update_all.go
@@ -136,11 +136,11 @@ var updateAllCmd = &cobra.Command{
 				continue
 			}
 
-			logging.Infof("\nUpdate complete: %s → %s\n", res.OldVersion, res.NewVersion)
+			logging.Infof("\nUpdate complete: %s\n", versionTransition(res.OldVersion, res.NewVersion))
 			logging.Infof("  Mods: %d added, %d removed, %d updated, %d unchanged\n",
 				res.Added, res.Removed, res.Updated, res.Unchanged)
 			if res.ConfigUpdated {
-				logging.Infoln("  Pack configs: updated to new version")
+				logging.Infof("  Pack configs: %s → %s\n", res.OldConfigVersion, res.NewConfigVersion)
 			}
 			if len(res.StampedFiles) > 0 {
 				logging.Infof("  Version stamped into %d file(s)\n", len(res.StampedFiles))
@@ -158,8 +158,8 @@ var updateAllCmd = &cobra.Command{
 				continue
 			}
 			modsChanged := r.result.Added + r.result.Removed + r.result.Updated
-			logging.Infof("  %-20s  OK     %s → %s   %d updated\n",
-				r.name, r.result.OldVersion, r.result.NewVersion, modsChanged)
+			logging.Infof("  %-20s  OK     %s   %d updated\n",
+				r.name, versionCell(r.result.OldVersion, r.result.NewVersion), modsChanged)
 		}
 
 		return firstErr

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -11,13 +11,17 @@ import (
 const StateFile = ".gtnh-daily-updater.json"
 
 type LocalState struct {
-	Side          string                  `json:"side"`
-	Mode          string                  `json:"mode,omitempty"`
-	ManifestDate  string                  `json:"manifest_date"`
-	ConfigVersion string                  `json:"config_version"`
-	Mods          map[string]InstalledMod `json:"mods"`
-	ExcludeMods   []string                `json:"exclude_mods,omitempty"`
-	ExtraMods     map[string]ExtraModSpec `json:"extra_mods,omitempty"`
+	Side          string `json:"side"`
+	Mode          string `json:"mode,omitempty"`
+	ManifestDate  string `json:"manifest_date"`
+	ConfigVersion string `json:"config_version"`
+	// DisplayVersion is the pack version as shown in game, e.g.
+	// "2.9.x (Daily 648) - 2026-07-28". Empty on state files written before
+	// this was tracked.
+	DisplayVersion string                  `json:"display_version,omitempty"`
+	Mods           map[string]InstalledMod `json:"mods"`
+	ExcludeMods    []string                `json:"exclude_mods,omitempty"`
+	ExtraMods      map[string]ExtraModSpec `json:"extra_mods,omitempty"`
 }
 
 type ExtraModSpec struct {

--- a/internal/config/state_test.go
+++ b/internal/config/state_test.go
@@ -98,3 +98,49 @@ func TestGameDir(t *testing.T) {
 		}
 	})
 }
+
+func TestSaveAndLoadDisplayVersion(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	s := &LocalState{
+		Side:           "client",
+		ManifestDate:   "2026-07-28",
+		ConfigVersion:  "2.9.0-nightly-2026-07-28",
+		DisplayVersion: "2.9.x (Daily 648) - 2026-07-28",
+	}
+	if err := s.Save(tmp); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load(tmp)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.DisplayVersion != "2.9.x (Daily 648) - 2026-07-28" {
+		t.Errorf("DisplayVersion = %q, want %q", loaded.DisplayVersion, "2.9.x (Daily 648) - 2026-07-28")
+	}
+}
+
+func TestLoadStateWithoutDisplayVersion(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	older := `{
+  "side": "client",
+  "manifest_date": "2026-07-27",
+  "config_version": "2.9.0-nightly-2026-07-27",
+  "mods": {}
+}`
+	if err := os.WriteFile(filepath.Join(tmp, StateFile), []byte(older), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(tmp)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.DisplayVersion != "" {
+		t.Errorf("DisplayVersion = %q, want empty for a pre-feature state file", loaded.DisplayVersion)
+	}
+}

--- a/internal/updater/regression_test.go
+++ b/internal/updater/regression_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
 	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/fileutil"
-	"github.com/caedis/gtnh-daily-updater/internal/github"
 	"github.com/caedis/gtnh-daily-updater/internal/gitconfigs"
+	"github.com/caedis/gtnh-daily-updater/internal/github"
 	"github.com/caedis/gtnh-daily-updater/internal/logging"
 	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 	"github.com/caedis/gtnh-daily-updater/internal/maven"
@@ -1080,7 +1080,7 @@ func TestStatus_ResolvesUnpinnedExtraVersionsBeforeDiff(t *testing.T) {
 		_ = logging.SetOutputFile("")
 	}()
 
-	if err := Status(context.Background(), instanceDir, ""); err != nil {
+	if err := Status(context.Background(), instanceDir, "", ""); err != nil {
 		t.Fatalf("Status failed: %v", err)
 	}
 
@@ -1091,6 +1091,80 @@ func TestStatus_ResolvesUnpinnedExtraVersionsBeforeDiff(t *testing.T) {
 	text := string(output)
 	if !strings.Contains(text, "0 added, 0 removed, 0 updated, 1 unchanged") {
 		t.Fatalf("unexpected status summary output:\n%s", text)
+	}
+}
+
+// TestRun_AlreadyUpToDateRecordsDisplayVersion pins the only path by which an
+// instance that predates display-version tracking (empty state.DisplayVersion)
+// ever acquires one: the already-up-to-date early return in Run. Without that
+// call, such an instance would show a raw manifest timestamp in `status`
+// forever, since persistUpdatedState is never reached on this path.
+func TestRun_AlreadyUpToDateRecordsDisplayVersion(t *testing.T) {
+	instanceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+
+	const manifestDate = "2026-07-28T13:58:48.371055+00:00"
+	const configVersion = "2.9.0-nightly-2026-07-28"
+
+	state := &config.LocalState{
+		Side:          "client",
+		ManifestDate:  manifestDate,
+		ConfigVersion: configVersion,
+		Mods:          map[string]config.InstalledMod{},
+	}
+	if err := state.Save(instanceDir); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	server := newUpdaterMockServer(t, mockManifestAndAssets{
+		manifest: map[string]any{
+			"version":       "daily",
+			"last_version":  "daily-previous",
+			"last_updated":  manifestDate,
+			"config":        configVersion,
+			"github_mods":   map[string]any{},
+			"external_mods": map[string]any{},
+		},
+		assets: map[string]any{
+			"config":              map[string]any{"versions": []any{}},
+			"mods":                []any{},
+			"latest_daily":        648,
+			"latest_experimental": 141,
+		},
+	})
+	restoreClient := rewriteDefaultHTTPClient(t, server)
+
+	// Pre-fetch SharedData exactly as update-all does, then take the server
+	// offline: the up-to-date path below must make no further network calls.
+	shared, err := FetchSharedData(context.Background(), "daily")
+	if err != nil {
+		t.Fatalf("FetchSharedData failed: %v", err)
+	}
+	restoreClient()
+	server.Close()
+
+	// Force is intentionally NOT set: it skips the early-return branch under
+	// test entirely (it forces a real update path instead).
+	result, err := Run(context.Background(), Options{
+		InstanceDir: instanceDir,
+		Shared:      shared,
+	})
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if !result.UpToDate {
+		t.Fatalf("expected UpToDate=true, got result: %+v", result)
+	}
+
+	updatedState, err := config.Load(instanceDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	const wantDisplay = "2.9.x (Daily 648) - 2026-07-28"
+	if updatedState.DisplayVersion != wantDisplay {
+		t.Fatalf("DisplayVersion = %q, want %q", updatedState.DisplayVersion, wantDisplay)
 	}
 }
 
@@ -1326,8 +1400,8 @@ func TestResolveLatest_AuthFailsFallsBackToAnon(t *testing.T) {
 		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
 			writeJSON(t, w, map[string]any{
 				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
-				"config":      "cfg-1",
-				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
 				"external_mods": map[string]any{},
 			})
 		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
@@ -1416,8 +1490,8 @@ func TestResolveLatest_GitHubUnreachableUsesMaven(t *testing.T) {
 		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
 			writeJSON(t, w, map[string]any{
 				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
-				"config":      "cfg-1",
-				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
 				"external_mods": map[string]any{},
 			})
 		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
@@ -1495,8 +1569,8 @@ func TestResolveLatest_GitHubOlderDoesNotConsultMaven(t *testing.T) {
 		case "/GTNewHorizons/DreamAssemblerXXL/master/releases/manifests/daily.json":
 			writeJSON(t, w, map[string]any{
 				"version": "daily", "last_version": "daily-previous", "last_updated": "2026-02-20",
-				"config":      "cfg-1",
-				"github_mods": map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
+				"config":        "cfg-1",
+				"github_mods":   map[string]any{"TestMod": map[string]any{"version": "1.0.0", "side": "BOTH"}},
 				"external_mods": map[string]any{},
 			})
 		case "/GTNewHorizons/DreamAssemblerXXL/master/gtnh-assets.json":
@@ -1680,4 +1754,96 @@ func TestRun_StampsVersionAfterConfigSnapshot(t *testing.T) {
 	if strings.TrimSpace(repoContent) != strings.TrimSpace(defaultLine) {
 		t.Fatalf("snapshot commit content = %q, want unstamped default %q", repoContent, defaultLine)
 	}
+}
+
+// TestRun_OldVersionFallsBackToConfigVersion pins the OldVersion/NewVersion/
+// OldConfigVersion/NewConfigVersion fields on UpdateResult: OldVersion mirrors
+// state.DisplayVersion when set, and falls back to state.ConfigVersion for a
+// pre-feature instance that never recorded one.
+func TestRun_OldVersionFallsBackToConfigVersion(t *testing.T) {
+	const cfgVersion = "2.9.0-nightly-2026-07-28"
+	m := &manifest.DailyManifest{
+		Version:      "daily",
+		LastUpdated:  "2026-07-28T00:00:00+00:00",
+		Config:       cfgVersion, // unchanged vs state: keeps the run offline (no ApplyUpdate)
+		GithubMods:   map[string]manifest.ModInfo{},
+		ExternalMods: map[string]manifest.ModInfo{},
+	}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	wantNewVersion := "2.9.x (Daily 648) - 2026-07-28"
+
+	t.Run("with stored DisplayVersion", func(t *testing.T) {
+		instanceDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+			t.Fatalf("MkdirAll failed: %v", err)
+		}
+		state := &config.LocalState{
+			Side:           "server",
+			ManifestDate:   "2026-07-27",
+			ConfigVersion:  cfgVersion,
+			DisplayVersion: "2.9.x (Daily 600) - 2026-07-01",
+			Mods:           map[string]config.InstalledMod{},
+		}
+		if err := state.Save(instanceDir); err != nil {
+			t.Fatalf("Save failed: %v", err)
+		}
+
+		result, err := Run(context.Background(), Options{
+			InstanceDir: instanceDir,
+			Force:       true,
+			Shared:      &SharedData{Manifest: m, AssetsDB: db, Mode: "daily"},
+		})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if result.OldVersion != "2.9.x (Daily 600) - 2026-07-01" {
+			t.Errorf("OldVersion = %q, want stored DisplayVersion", result.OldVersion)
+		}
+		if result.NewVersion != wantNewVersion {
+			t.Errorf("NewVersion = %q, want %q", result.NewVersion, wantNewVersion)
+		}
+		if result.OldConfigVersion != cfgVersion {
+			t.Errorf("OldConfigVersion = %q, want %q", result.OldConfigVersion, cfgVersion)
+		}
+		if result.NewConfigVersion != cfgVersion {
+			t.Errorf("NewConfigVersion = %q, want %q", result.NewConfigVersion, cfgVersion)
+		}
+	})
+
+	t.Run("without stored DisplayVersion falls back to ConfigVersion", func(t *testing.T) {
+		instanceDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(instanceDir, "mods"), 0o755); err != nil {
+			t.Fatalf("MkdirAll failed: %v", err)
+		}
+		state := &config.LocalState{
+			Side:          "server",
+			ManifestDate:  "2026-07-27",
+			ConfigVersion: cfgVersion,
+			Mods:          map[string]config.InstalledMod{},
+		}
+		if err := state.Save(instanceDir); err != nil {
+			t.Fatalf("Save failed: %v", err)
+		}
+
+		result, err := Run(context.Background(), Options{
+			InstanceDir: instanceDir,
+			Force:       true,
+			Shared:      &SharedData{Manifest: m, AssetsDB: db, Mode: "daily"},
+		})
+		if err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		if result.OldVersion != cfgVersion {
+			t.Errorf("OldVersion = %q, want fallback to ConfigVersion %q", result.OldVersion, cfgVersion)
+		}
+		if result.NewVersion != wantNewVersion {
+			t.Errorf("NewVersion = %q, want %q", result.NewVersion, wantNewVersion)
+		}
+		if result.OldConfigVersion != cfgVersion {
+			t.Errorf("OldConfigVersion = %q, want %q", result.OldConfigVersion, cfgVersion)
+		}
+		if result.NewConfigVersion != cfgVersion {
+			t.Errorf("NewConfigVersion = %q, want %q", result.NewConfigVersion, cfgVersion)
+		}
+	})
 }

--- a/internal/updater/run.go
+++ b/internal/updater/run.go
@@ -73,18 +73,33 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 
 	added, removed, updated, unchanged := diff.Summary(changes)
 	logging.Debugf("Verbose: diff summary added=%d removed=%d updated=%d unchanged=%d\n", added, removed, updated, unchanged)
+
+	displayVersion := buildDisplayVersion(m, db, mode, effectiveConfigVersion, opts)
+	// Instances updated before display versions were tracked have none stored;
+	// show the config tag they do have.
+	oldDisplay := state.DisplayVersion
+	if oldDisplay == "" {
+		oldDisplay = state.ConfigVersion
+	}
+
 	result := &UpdateResult{
-		OldVersion: state.ConfigVersion,
-		NewVersion: effectiveConfigVersion,
-		Added:      added,
-		Removed:    removed,
-		Updated:    updated,
-		Unchanged:  unchanged,
+		OldVersion:       oldDisplay,
+		NewVersion:       displayVersion.Long,
+		OldConfigVersion: state.ConfigVersion,
+		NewConfigVersion: effectiveConfigVersion,
+		Added:            added,
+		Removed:          removed,
+		Updated:          updated,
+		Unchanged:        unchanged,
 	}
 
 	if !opts.Force && !opts.DryRun && result.Added == 0 && result.Removed == 0 && result.Updated == 0 && state.ConfigVersion == effectiveConfigVersion {
 		result.UpToDate = true
-		stampVersionIfNeeded(opts.InstanceDir, gameDir, m, db, mode, effectiveConfigVersion, opts, result)
+		stampVersionIfNeeded(opts.InstanceDir, gameDir, displayVersion, opts, result)
+		// Record the display version here too: this path never reaches
+		// persistUpdatedState, so a pre-feature instance would otherwise stay on
+		// the empty fallback forever despite having its configs re-stamped.
+		recordDisplayVersionIfChanged(opts.InstanceDir, state, displayVersion.Long)
 		logging.Infoln("Already up to date.")
 		return result, nil
 	}
@@ -123,8 +138,8 @@ func Run(ctx context.Context, opts Options) (*UpdateResult, error) {
 		return nil, err
 	}
 	// After the config merge, which restores the pack's default version lines.
-	stampVersionIfNeeded(opts.InstanceDir, gameDir, m, db, mode, effectiveConfigVersion, opts, result)
-	if err := persistUpdatedState(ctx, state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion, result); err != nil {
+	stampVersionIfNeeded(opts.InstanceDir, gameDir, displayVersion, opts, result)
+	if err := persistUpdatedState(ctx, state, changes, m, mode, opts, db, extraDownloads, latestDownloads, rollback, effectiveConfigVersion, displayVersion.Long, result); err != nil {
 		return nil, err
 	}
 

--- a/internal/updater/status.go
+++ b/internal/updater/status.go
@@ -13,17 +13,18 @@ import (
 )
 
 // Status shows the current state vs latest available.
-func Status(ctx context.Context, instanceDir, githubToken string) error {
+func Status(ctx context.Context, instanceDir, githubToken, curseforgeKey string) error {
 	state, err := config.Load(instanceDir)
 	if err != nil {
 		return err
 	}
 	logging.Debugf(
-		"Verbose: status state side=%s mode=%s manifest-date=%q config=%s mods=%d excluded=%d extras=%d\n",
+		"Verbose: status state side=%s mode=%s manifest-date=%q config=%s display=%q mods=%d excluded=%d extras=%d\n",
 		state.Side,
 		resolveMode(state),
 		state.ManifestDate,
 		state.ConfigVersion,
+		state.DisplayVersion,
 		len(state.Mods),
 		len(state.ExcludeMods),
 		len(state.ExtraMods),
@@ -37,25 +38,39 @@ func Status(ctx context.Context, instanceDir, githubToken string) error {
 	}
 	logging.Debugf("Verbose: status manifest updated=%s config=%s\n", m.LastUpdated, m.Config)
 
+	upToDate := m.LastUpdated == state.ManifestDate
+
+	// Print what needs no lookup first, so a failed fetch below still leaves
+	// the user with something.
 	logging.Infof("Side:      %s\n", state.Side)
 	logging.Infof("Mode:      %s\n", mode)
-	logging.Infof("Current:   %s\n", state.ManifestDate)
-	logging.Infof("Latest:    %s\n", m.LastUpdated)
 
-	if m.LastUpdated == state.ManifestDate {
+	// The counter for the latest build lives in the assets DB. An up-to-date
+	// instance needs no counter, so it pays for no fetch.
+	var db *assets.AssetsDB
+	if !upToDate {
+		logging.Infoln("Fetching assets database...")
+		db, err = assets.Fetch(ctx)
+		if err != nil {
+			return fmt.Errorf("fetching assets DB: %w", err)
+		}
+	}
+
+	current, latest := statusVersions(state, m, db, mode)
+	logging.Infof("Current:   %s\n", current)
+	logging.Infof("Latest:    %s\n", latest)
+
+	upToDate = finalizeUpToDate(upToDate, current, latest)
+
+	if upToDate {
 		logging.Infoln("\nAlready up to date.")
 		return nil
 	}
 
 	resolvedExtras := make(map[string]diff.ResolvedExtraMod)
 	if len(state.ExtraMods) > 0 {
-		logging.Infoln("Fetching assets database...")
-		db, err := assets.Fetch(ctx)
-		if err != nil {
-			return fmt.Errorf("fetching assets DB: %w", err)
-		}
 		var resolvedErr error
-		resolvedExtras, _, resolvedErr = resolveConfiguredExtras(ctx, state, db, Options{GithubToken: githubToken})
+		resolvedExtras, _, resolvedErr = resolveConfiguredExtras(ctx, state, db, Options{GithubToken: githubToken, CurseForgeKey: curseforgeKey})
 		if resolvedErr != nil {
 			return fmt.Errorf("resolving extra mods: %w", resolvedErr)
 		}
@@ -88,4 +103,26 @@ func Status(ctx context.Context, instanceDir, githubToken string) error {
 	}
 
 	return nil
+}
+
+// finalizeUpToDate re-checks up-to-date status once the display strings are
+// known: a manifest regenerated with no real change advances LastUpdated
+// without a real difference, so identical Current/Latest strings also count.
+// cheapUpToDate is the pre-computed m.LastUpdated == state.ManifestDate check,
+// which avoids the assets DB fetch when it alone is already true.
+func finalizeUpToDate(cheapUpToDate bool, current, latest string) bool {
+	return cheapUpToDate || current == latest
+}
+
+// statusVersions returns the display strings for the Current and Latest lines.
+// db is nil when the instance is up to date, in which case latest == current.
+func statusVersions(state *config.LocalState, m *manifest.DailyManifest, db *assets.AssetsDB, mode string) (current, latest string) {
+	current = state.DisplayVersion
+	if current == "" {
+		current = state.ConfigVersion
+	}
+	if db == nil {
+		return current, current
+	}
+	return current, buildDisplayVersion(m, db, mode, m.Config, Options{}).Long
 }

--- a/internal/updater/status_test.go
+++ b/internal/updater/status_test.go
@@ -1,0 +1,117 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/caedis/gtnh-daily-updater/internal/assets"
+	"github.com/caedis/gtnh-daily-updater/internal/config"
+	"github.com/caedis/gtnh-daily-updater/internal/manifest"
+)
+
+func TestStatusVersions(t *testing.T) {
+	m := &manifest.DailyManifest{
+		LastUpdated: "2026-07-28T13:58:48.371055+00:00",
+		Config:      "2.9.0-nightly-2026-07-28",
+	}
+	db := &assets.AssetsDB{LatestDaily: 648, LatestExperimental: 141}
+
+	tests := []struct {
+		name        string
+		state       *config.LocalState
+		db          *assets.AssetsDB
+		mode        string
+		wantCurrent string
+		wantLatest  string
+	}{
+		{
+			name:        "stored display version",
+			state:       &config.LocalState{ManifestDate: "2026-07-27", DisplayVersion: "2.9.x (Daily 647) - 2026-07-27"},
+			db:          db,
+			mode:        manifest.ModeDaily,
+			wantCurrent: "2.9.x (Daily 647) - 2026-07-27",
+			wantLatest:  "2.9.x (Daily 648) - 2026-07-28",
+		},
+		{
+			name: "no stored display version falls back to config version",
+			state: &config.LocalState{
+				ManifestDate:  "2026-07-27T11:04:12.331+00:00",
+				ConfigVersion: "2.9.0-nightly-2026-07-27",
+			},
+			db:          db,
+			mode:        manifest.ModeDaily,
+			wantCurrent: "2.9.0-nightly-2026-07-27",
+			wantLatest:  "2.9.x (Daily 648) - 2026-07-28",
+		},
+		{
+			name:        "experimental uses its own counter",
+			state:       &config.LocalState{ManifestDate: "2026-07-27", DisplayVersion: "2.9.x (Experimental 140) - 2026-07-27"},
+			db:          db,
+			mode:        manifest.ModeExperimental,
+			wantCurrent: "2.9.x (Experimental 140) - 2026-07-27",
+			wantLatest:  "2.9.x (Experimental 141) - 2026-07-28",
+		},
+		{
+			name:        "up to date needs no assets db",
+			state:       &config.LocalState{ManifestDate: "2026-07-28", DisplayVersion: "2.9.x (Daily 648) - 2026-07-28"},
+			db:          nil,
+			mode:        manifest.ModeDaily,
+			wantCurrent: "2.9.x (Daily 648) - 2026-07-28",
+			wantLatest:  "2.9.x (Daily 648) - 2026-07-28",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			current, latest := statusVersions(tc.state, m, tc.db, tc.mode)
+			if current != tc.wantCurrent {
+				t.Errorf("current = %q, want %q", current, tc.wantCurrent)
+			}
+			if latest != tc.wantLatest {
+				t.Errorf("latest = %q, want %q", latest, tc.wantLatest)
+			}
+		})
+	}
+}
+
+// TestFinalizeUpToDate covers a manifest regenerated with no real change: the
+// cheap timestamp check misses it (LastUpdated advanced), but Current and
+// Latest come out identical, so the instance must still read as up to date.
+func TestFinalizeUpToDate(t *testing.T) {
+	tests := []struct {
+		name          string
+		cheapUpToDate bool
+		current       string
+		latest        string
+		want          bool
+	}{
+		{
+			name:          "cheap check already true",
+			cheapUpToDate: true,
+			current:       "2.9.x (Daily 648) - 2026-07-28",
+			latest:        "2.9.x (Daily 649) - 2026-07-29",
+			want:          true,
+		},
+		{
+			name:          "regenerated manifest but identical display strings",
+			cheapUpToDate: false,
+			current:       "2.9.x (Daily 648) - 2026-07-28",
+			latest:        "2.9.x (Daily 648) - 2026-07-28",
+			want:          true,
+		},
+		{
+			name:          "real difference",
+			cheapUpToDate: false,
+			current:       "2.9.x (Daily 647) - 2026-07-27",
+			latest:        "2.9.x (Daily 648) - 2026-07-28",
+			want:          false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := finalizeUpToDate(tc.cheapUpToDate, tc.current, tc.latest); got != tc.want {
+				t.Errorf("finalizeUpToDate(%v, %q, %q) = %v, want %v", tc.cheapUpToDate, tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -33,14 +33,20 @@ type Options struct {
 }
 
 type UpdateResult struct {
-	OldVersion    string
-	NewVersion    string
-	Added         int
-	Removed       int
-	Updated       int
-	Unchanged     int
-	ConfigUpdated bool
-	ConfigSkipped bool
+	// OldVersion and NewVersion hold the pack display version shown in
+	// summaries, e.g. "2.9.x (Daily 648) - 2026-07-28". OldVersion falls back
+	// to the config repo tag when no display version was recorded yet.
+	OldVersion string
+	NewVersion string
+	// OldConfigVersion and NewConfigVersion hold the config repo tags.
+	OldConfigVersion string
+	NewConfigVersion string
+	Added            int
+	Removed          int
+	Updated          int
+	Unchanged        int
+	ConfigUpdated    bool
+	ConfigSkipped    bool
 	// StampedFiles lists pack files whose version stamp was rewritten.
 	StampedFiles []string
 	Skipped      []string

--- a/internal/updater/versionstamp_test.go
+++ b/internal/updater/versionstamp_test.go
@@ -1,12 +1,14 @@
 package updater
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
 	"testing"
 
 	"github.com/caedis/gtnh-daily-updater/internal/assets"
+	"github.com/caedis/gtnh-daily-updater/internal/config"
 	"github.com/caedis/gtnh-daily-updater/internal/manifest"
 )
 
@@ -40,7 +42,8 @@ func TestStampVersionIfNeededStampsDailyVersion(t *testing.T) {
 	db := &assets.AssetsDB{LatestDaily: 648}
 	result := &UpdateResult{}
 
-	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{}, result)
+	v := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{})
+	stampVersionIfNeeded(instanceDir, gameDir, v, Options{}, result)
 
 	if !slices.Contains(result.StampedFiles, "config/DreamCoreMod.properties") {
 		t.Fatalf("StampedFiles = %v, want DreamCoreMod.properties", result.StampedFiles)
@@ -76,7 +79,8 @@ func TestStampVersionIfNeededSkipsDryRunAndOptOut(t *testing.T) {
 		db := &assets.AssetsDB{LatestDaily: 648}
 		result := &UpdateResult{}
 
-		stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", opts, result)
+		v := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", opts)
+		stampVersionIfNeeded(instanceDir, gameDir, v, opts, result)
 
 		if len(result.StampedFiles) != 0 {
 			t.Errorf("opts %+v: StampedFiles = %v, want none", opts, result.StampedFiles)
@@ -101,7 +105,8 @@ func TestStampVersionIfNeededSkipsWhenConfigSkipped(t *testing.T) {
 	db := &assets.AssetsDB{LatestDaily: 648}
 	result := &UpdateResult{ConfigSkipped: true}
 
-	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{}, result)
+	v := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{})
+	stampVersionIfNeeded(instanceDir, gameDir, v, Options{}, result)
 
 	if len(result.StampedFiles) != 0 {
 		t.Errorf("StampedFiles = %v, want none", result.StampedFiles)
@@ -128,7 +133,8 @@ func TestStampVersionIfNeededUsesExperimentalCounter(t *testing.T) {
 	db := &assets.AssetsDB{LatestDaily: 648, LatestExperimental: 141}
 	result := &UpdateResult{}
 
-	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeExperimental, "2.9.0-nightly-2026-07-28", Options{}, result)
+	v := buildDisplayVersion(m, db, manifest.ModeExperimental, "2.9.0-nightly-2026-07-28", Options{})
+	stampVersionIfNeeded(instanceDir, gameDir, v, Options{}, result)
 
 	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
 	if err != nil {
@@ -146,7 +152,8 @@ func TestStampVersionIfNeededLatestMarksCountWithPlus(t *testing.T) {
 	db := &assets.AssetsDB{LatestDaily: 648}
 	result := &UpdateResult{}
 
-	stampVersionIfNeeded(instanceDir, gameDir, m, db, manifest.ModeDaily, "2.9.0", Options{Latest: true}, result)
+	v := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0", Options{Latest: true})
+	stampVersionIfNeeded(instanceDir, gameDir, v, Options{Latest: true}, result)
 
 	got, err := os.ReadFile(filepath.Join(gameDir, "config", "DreamCoreMod.properties"))
 	if err != nil {
@@ -155,5 +162,117 @@ func TestStampVersionIfNeededLatestMarksCountWithPlus(t *testing.T) {
 	want := "displayedModpackVersion=2.9.x (Daily 648+) - 2026-07-28\n"
 	if string(got) != want {
 		t.Errorf("properties = %q, want %q", got, want)
+	}
+}
+
+func TestBuildDisplayVersionUsesModeCounter(t *testing.T) {
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648, LatestExperimental: 141}
+
+	daily := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{})
+	if daily.Long != "2.9.x (Daily 648) - 2026-07-28" {
+		t.Errorf("daily = %q", daily.Long)
+	}
+
+	exp := buildDisplayVersion(m, db, manifest.ModeExperimental, "2.9.0-nightly-2026-07-28", Options{})
+	if exp.Long != "2.9.x (Experimental 141) - 2026-07-28" {
+		t.Errorf("experimental = %q", exp.Long)
+	}
+
+	latest := buildDisplayVersion(m, db, manifest.ModeDaily, "2.9.0-nightly-2026-07-28", Options{Latest: true})
+	if latest.Long != "2.9.x (Daily 648+) - 2026-07-28" {
+		t.Errorf("latest = %q", latest.Long)
+	}
+}
+
+// TestRecordDisplayVersionIfChanged covers the already-up-to-date early
+// return in run.go, which never reaches persistUpdatedState: a pre-feature
+// instance (empty DisplayVersion) must get the built version recorded, and a
+// second identical call must leave the file untouched (no-op save).
+func TestRecordDisplayVersionIfChanged(t *testing.T) {
+	tmp := t.TempDir()
+	state := &config.LocalState{Side: "server", ConfigVersion: "cfg-1", Mods: map[string]config.InstalledMod{}}
+	if err := state.Save(tmp); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	recordDisplayVersionIfChanged(tmp, state, "2.9.x (Daily 648) - 2026-07-28")
+
+	loaded, err := config.Load(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.DisplayVersion != "2.9.x (Daily 648) - 2026-07-28" {
+		t.Errorf("DisplayVersion = %q, want stamped", loaded.DisplayVersion)
+	}
+
+	statBefore, err := os.Stat(filepath.Join(tmp, config.StateFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call with the already-recorded value: must not rewrite the file.
+	recordDisplayVersionIfChanged(tmp, state, "2.9.x (Daily 648) - 2026-07-28")
+
+	statAfter, err := os.Stat(filepath.Join(tmp, config.StateFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statBefore.ModTime() != statAfter.ModTime() {
+		t.Errorf("state file was rewritten on an unchanged call: before=%v after=%v", statBefore.ModTime(), statAfter.ModTime())
+	}
+}
+
+func TestPersistUpdatedStateStoresDisplayVersion(t *testing.T) {
+	tmp := t.TempDir()
+	state := &config.LocalState{Side: "server", ConfigVersion: "cfg-old", Mods: map[string]config.InstalledMod{}}
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	result := &UpdateResult{}
+	rollback := func(err error) error { return err }
+
+	err := persistUpdatedState(context.Background(), state, nil, m, manifest.ModeDaily,
+		Options{InstanceDir: tmp}, db, nil, nil, rollback,
+		"cfg-new", "2.9.x (Daily 648) - 2026-07-28", result)
+	if err != nil {
+		t.Fatalf("persistUpdatedState: %v", err)
+	}
+
+	loaded, err := config.Load(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.DisplayVersion != "2.9.x (Daily 648) - 2026-07-28" {
+		t.Errorf("DisplayVersion = %q", loaded.DisplayVersion)
+	}
+	if loaded.ConfigVersion != "cfg-new" {
+		t.Errorf("ConfigVersion = %q, want cfg-new", loaded.ConfigVersion)
+	}
+}
+
+func TestPersistUpdatedStateSkipsDisplayVersionWhenConfigSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	state := &config.LocalState{Side: "server", ConfigVersion: "cfg-old", Mods: map[string]config.InstalledMod{}}
+	m := &manifest.DailyManifest{LastUpdated: "2026-07-28T13:58:48.371055+00:00"}
+	db := &assets.AssetsDB{LatestDaily: 648}
+	result := &UpdateResult{ConfigSkipped: true}
+	rollback := func(err error) error { return err }
+
+	err := persistUpdatedState(context.Background(), state, nil, m, manifest.ModeDaily,
+		Options{InstanceDir: tmp}, db, nil, nil, rollback,
+		"cfg-new", "2.9.x (Daily 648) - 2026-07-28", result)
+	if err != nil {
+		t.Fatalf("persistUpdatedState: %v", err)
+	}
+
+	loaded, err := config.Load(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.DisplayVersion != "" {
+		t.Errorf("DisplayVersion = %q, want empty when the config update was skipped", loaded.DisplayVersion)
+	}
+	if loaded.ConfigVersion != "cfg-old" {
+		t.Errorf("ConfigVersion = %q, want cfg-old", loaded.ConfigVersion)
 	}
 }

--- a/internal/updater/workflow_steps.go
+++ b/internal/updater/workflow_steps.go
@@ -51,11 +51,12 @@ func loadAndLogState(instanceDir string) (*config.LocalState, error) {
 		return nil, err
 	}
 	logging.Debugf(
-		"Verbose: loaded state side=%s mode=%s manifest-date=%q config=%s mods=%d excluded=%d extras=%d\n",
+		"Verbose: loaded state side=%s mode=%s manifest-date=%q config=%s display=%q mods=%d excluded=%d extras=%d\n",
 		state.Side,
 		resolveMode(state),
 		state.ManifestDate,
 		state.ConfigVersion,
+		state.DisplayVersion,
 		len(state.Mods),
 		len(state.ExcludeMods),
 		len(state.ExtraMods),
@@ -419,7 +420,7 @@ func snapshotAndUpdateConfigsIfNeeded(ctx context.Context, state *config.LocalSt
 	return nil
 }
 
-func persistUpdatedState(ctx context.Context, state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error, configVersion string, result *UpdateResult) error {
+func persistUpdatedState(ctx context.Context, state *config.LocalState, changes []diff.ModChange, m *manifest.DailyManifest, mode string, opts Options, db *assets.AssetsDB, extraDownloads, latestDownloads map[string]resolvedExtra, rollback func(error) error, configVersion, displayVersion string, result *UpdateResult) error {
 	for _, c := range changes {
 		switch c.Type {
 		case diff.Added, diff.Updated:
@@ -451,6 +452,7 @@ func persistUpdatedState(ctx context.Context, state *config.LocalState, changes 
 
 	if !result.ConfigSkipped {
 		state.ConfigVersion = configVersion
+		state.DisplayVersion = displayVersion
 	}
 	state.ManifestDate = m.LastUpdated
 	state.Mode = mode
@@ -458,14 +460,40 @@ func persistUpdatedState(ctx context.Context, state *config.LocalState, changes 
 	if err := state.Save(opts.InstanceDir); err != nil {
 		return rollback(fmt.Errorf("saving state: %w", err))
 	}
-	logging.Debugf("Verbose: saved state with mode=%s manifest-date=%s config=%s\n", state.Mode, state.ManifestDate, state.ConfigVersion)
+	logging.Debugf("Verbose: saved state with mode=%s manifest-date=%s config=%s display=%s\n", state.Mode, state.ManifestDate, state.ConfigVersion, state.DisplayVersion)
 
 	return nil
 }
 
+// recordDisplayVersionIfChanged saves state.DisplayVersion when it differs
+// from displayVersion. Used on the already-up-to-date path, where configs get
+// re-stamped every run but persistUpdatedState never runs — without this an
+// instance predating this feature would stay on the empty fallback forever.
+// A save failure is cosmetic (matches stampVersionIfNeeded): warn and continue.
+func recordDisplayVersionIfChanged(instanceDir string, state *config.LocalState, displayVersion string) {
+	if state.DisplayVersion == displayVersion {
+		return
+	}
+	state.DisplayVersion = displayVersion
+	if err := state.Save(instanceDir); err != nil {
+		logging.Infof("  Warning: saving display version failed: %v\n", err)
+	}
+}
+
+// buildDisplayVersion assembles the pack version string shown in summaries and
+// stamped into configs.
+func buildDisplayVersion(m *manifest.DailyManifest, db *assets.AssetsDB, mode, configVersion string, opts Options) versionstamp.DisplayVersion {
+	count := db.LatestDaily
+	if mode == manifest.ModeExperimental {
+		count = db.LatestExperimental
+	}
+	// --latest picks mods past the counted build, marked with a "+" on the count.
+	return versionstamp.Build(configVersion, mode, count, m.LastUpdated, opts.Latest)
+}
+
 // stampVersionIfNeeded writes the installed pack version into the files DAXXL
 // stamps at assembly time. Purely cosmetic, so failures only warn.
-func stampVersionIfNeeded(instanceDir, gameDir string, m *manifest.DailyManifest, db *assets.AssetsDB, mode, configVersion string, opts Options, result *UpdateResult) {
+func stampVersionIfNeeded(instanceDir, gameDir string, v versionstamp.DisplayVersion, opts Options, result *UpdateResult) {
 	if opts.DryRun || opts.NoVersionStamp {
 		return
 	}
@@ -476,13 +504,6 @@ func stampVersionIfNeeded(instanceDir, gameDir string, m *manifest.DailyManifest
 		return
 	}
 
-	count := db.LatestDaily
-	if mode == manifest.ModeExperimental {
-		count = db.LatestExperimental
-	}
-
-	// --latest picks mods past the counted build, marked with a "+" on the count.
-	v := versionstamp.Build(configVersion, mode, count, m.LastUpdated, opts.Latest)
 	stamped, err := versionstamp.Apply(instanceDir, gameDir, v)
 	if err != nil {
 		logging.Infof("  Warning: version stamping failed: %v\n", err)


### PR DESCRIPTION
Includes a status CF fix as well

Going from `--latest` (mods newer than in the latest daily) to just latest daily
```
Update complete: 2.9.x (Daily 653+) - 2026-07-30 → 2.9.x (Daily 653) - 2026-07-30
  Mods: 0 added, 0 removed, 1 updated, 235 unchanged
  Version stamped into 3 file(s)
```

Running 
```
Update complete: 2.9.x (Daily 653) - 2026-07-30 (pack version unchanged)
  Mods: 0 added, 0 removed, 0 updated, 236 unchanged
```

Note: The first update after will have the old config repo version in the from